### PR TITLE
fix #516: Product status not working in frontend

### DIFF
--- a/src/assets/blocks/blocks.js
+++ b/src/assets/blocks/blocks.js
@@ -29172,7 +29172,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 
             var listCats = categories.join(',');
-            var shortCode = ['[products', "limit=\"" + numberOfProducts + "\"", "columns=\"" + columns + "\"", "orderby=\"" + orderBy + "\"", "order=\"" + order + "\"", category === 'selected' && "category=\"" + listCats + "\"", status === 'featured' && 'featured="1"', status === 'on_sale' && 'on_sale="1"', ']'].filter(Boolean).join(' ');
+            var shortCode = ['[products', "limit=\"" + numberOfProducts + "\"", "columns=\"" + columns + "\"", "orderby=\"" + orderBy + "\"", "order=\"" + order + "\"", category === 'selected' && "category=\"" + listCats + "\"", status === 'featured' && 'visibility="featured"', status === 'on_sale' && 'on_sale="1"', ']'].filter(Boolean).join(' ');
 
             var blockClassName = ['advgb-woo-products', viewType === 'slider' && 'slider-view'].filter(Boolean).join(' ');
 

--- a/src/assets/blocks/blocks.js
+++ b/src/assets/blocks/blocks.js
@@ -29101,6 +29101,47 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         return AdvProductsEdit;
     }(Component);
 
+    var attributes = {
+        viewType: {
+            type: 'string',
+            default: 'normal'
+        },
+        category: {
+            type: 'string'
+        },
+        categories: {
+            type: 'array',
+            default: []
+        },
+        status: {
+            type: 'string'
+        },
+        order: {
+            type: 'string',
+            default: 'desc'
+        },
+        orderBy: {
+            type: 'string',
+            default: 'date'
+        },
+        numberOfProducts: {
+            type: 'number',
+            default: 6
+        },
+        columns: {
+            type: 'number',
+            default: 3
+        },
+        changed: {
+            type: 'boolean',
+            default: false
+        },
+        isPreview: {
+            type: 'boolean',
+            default: false
+        }
+    };
+
     registerBlockType('advgb/woo-products', {
         title: __('Woo Products', 'advanced-gutenberg'),
         description: __('Listing your products in a easy way.', 'advanced-gutenberg'),
@@ -29110,46 +29151,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         },
         category: 'advgb-category',
         keywords: [__('woo commerce', 'advanced-gutenberg'), __('products list', 'advanced-gutenberg'), __('price list', 'advanced-gutenberg')],
-        attributes: {
-            viewType: {
-                type: 'string',
-                default: 'normal'
-            },
-            category: {
-                type: 'string'
-            },
-            categories: {
-                type: 'array',
-                default: []
-            },
-            status: {
-                type: 'string'
-            },
-            order: {
-                type: 'string',
-                default: 'desc'
-            },
-            orderBy: {
-                type: 'string',
-                default: 'date'
-            },
-            numberOfProducts: {
-                type: 'number',
-                default: 6
-            },
-            columns: {
-                type: 'number',
-                default: 3
-            },
-            changed: {
-                type: 'boolean',
-                default: false
-            },
-            isPreview: {
-                type: 'boolean',
-                default: false
-            }
-        },
+        attributes: attributes,
         example: {
             attributes: {
                 isPreview: true
@@ -29181,7 +29183,33 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
                 { className: blockClassName },
                 shortCode
             );
-        }
+        },
+        deprecated: [{
+            attributes: attributes,
+            save: function save(_ref2) {
+                var attributes = _ref2.attributes;
+                var viewType = attributes.viewType,
+                    category = attributes.category,
+                    categories = attributes.categories,
+                    status = attributes.status,
+                    order = attributes.order,
+                    orderBy = attributes.orderBy,
+                    numberOfProducts = attributes.numberOfProducts,
+                    columns = attributes.columns;
+
+
+                var listCats = categories.join(',');
+                var shortCode = ['[products', "limit=\"" + numberOfProducts + "\"", "columns=\"" + columns + "\"", "orderby=\"" + orderBy + "\"", "order=\"" + order + "\"", category === 'selected' && "category=\"" + listCats + "\"", status === 'featured' && 'featured="1"', status === 'on_sale' && 'on_sale="1"', ']'].filter(Boolean).join(' ');
+
+                var blockClassName = ['advgb-woo-products', viewType === 'slider' && 'slider-view'].filter(Boolean).join(' ');
+
+                return React.createElement(
+                    "div",
+                    { className: blockClassName },
+                    shortCode
+                );
+            }
+        }]
     });
 })(wp.i18n, wp.blocks, wp.element, wp.blockEditor, wp.components);
 

--- a/src/assets/blocks/woo-products/block.jsx
+++ b/src/assets/blocks/woo-products/block.jsx
@@ -432,7 +432,7 @@
                 `orderby="${orderBy}"`,
                 `order="${order}"`,
                 category === 'selected' && `category="${listCats}"`,
-                status === 'featured' && 'featured="1"',
+                status === 'featured' && 'visibility="featured"',
                 status === 'on_sale' && 'on_sale="1"',
                 ']',
             ].filter( Boolean ).join( ' ' );

--- a/src/assets/blocks/woo-products/block.jsx
+++ b/src/assets/blocks/woo-products/block.jsx
@@ -354,6 +354,47 @@
         }
     }
 
+    const attributes = {
+        viewType: {
+            type: 'string',
+            default: 'normal',
+        },
+        category: {
+            type: 'string',
+        },
+        categories: {
+            type: 'array',
+            default: [],
+        },
+        status: {
+            type: 'string',
+        },
+        order: {
+            type: 'string',
+            default: 'desc',
+        },
+        orderBy: {
+            type: 'string',
+            default: 'date',
+        },
+        numberOfProducts: {
+            type: 'number',
+            default: 6,
+        },
+        columns: {
+            type: 'number',
+            default: 3,
+        },
+        changed: {
+            type: 'boolean',
+            default: false,
+        },
+        isPreview: {
+            type: 'boolean',
+            default: false,
+        },
+    };
+
     registerBlockType( 'advgb/woo-products', {
         title: __( 'Woo Products', 'advanced-gutenberg' ),
         description: __( 'Listing your products in a easy way.', 'advanced-gutenberg' ),
@@ -363,46 +404,7 @@
         },
         category: 'advgb-category',
         keywords: [ __( 'woo commerce', 'advanced-gutenberg' ), __( 'products list', 'advanced-gutenberg' ), __( 'price list', 'advanced-gutenberg' ) ],
-        attributes: {
-            viewType: {
-                type: 'string',
-                default: 'normal',
-            },
-            category: {
-                type: 'string',
-            },
-            categories: {
-                type: 'array',
-                default: [],
-            },
-            status: {
-                type: 'string',
-            },
-            order: {
-                type: 'string',
-                default: 'desc',
-            },
-            orderBy: {
-                type: 'string',
-                default: 'date',
-            },
-            numberOfProducts: {
-                type: 'number',
-                default: 6,
-            },
-            columns: {
-                type: 'number',
-                default: 3,
-            },
-            changed: {
-                type: 'boolean',
-                default: false,
-            },
-            isPreview: {
-                type: 'boolean',
-                default: false,
-            },
-        },
+        attributes,
         example: {
             attributes: {
                 isPreview: true
@@ -447,6 +449,47 @@
                     {shortCode}
                 </div>
             );
-        }
+        },
+        deprecated: [
+            {
+                attributes,
+                save: function ( { attributes } ) {
+                    const {
+                        viewType,
+                        category,
+                        categories,
+                        status,
+                        order,
+                        orderBy,
+                        numberOfProducts,
+                        columns,
+                    } = attributes;
+
+                    const listCats = categories.join(',');
+                    const shortCode = [
+                        '[products',
+                        `limit="${numberOfProducts}"`,
+                        `columns="${columns}"`,
+                        `orderby="${orderBy}"`,
+                        `order="${order}"`,
+                        category === 'selected' && `category="${listCats}"`,
+                        status === 'featured' && 'featured="1"',
+                        status === 'on_sale' && 'on_sale="1"',
+                        ']',
+                    ].filter( Boolean ).join( ' ' );
+
+                    const blockClassName = [
+                        'advgb-woo-products',
+                        viewType === 'slider' && 'slider-view',
+                    ].filter( Boolean ).join( ' ' );
+
+                    return (
+                        <div className={ blockClassName }>
+                            {shortCode}
+                        </div>
+                    );
+                },
+            },
+        ],
     } )
 } )( wp.i18n, wp.blocks, wp.element, wp.blockEditor, wp.components );

--- a/src/assets/blocks/woo-products/controller.php
+++ b/src/assets/blocks/woo-products/controller.php
@@ -39,6 +39,14 @@ class AdvgbProductsController extends WC_REST_Products_Controller
             $args['meta_key'] = $ordering_args['meta_key'];
         }
 
+		// don't show hidden products
+		$args['tax_query'][] = array(
+			'taxonomy' => 'product_visibility',
+			'field'    => 'name',
+			'terms'    => array('exclude-from-catalog', 'exclude-from-search'),
+			'operator' => 'NOT IN'
+		);
+
         return $args;
     }
 


### PR DESCRIPTION
#516 

The problem appears to be the shortcode that is used and not what the user had shared in his troubleshooting. It looks like the shortcode, as per the documentation, should use `visibility="featured"` instead of `featured="1"`. 

![image](https://user-images.githubusercontent.com/12953439/119090759-a2a3c780-ba29-11eb-9ea6-8d0d03e61ba1.png)

I have corrected this. The existing blocks will fail validation but a block recovery fixes that. Do you think we should make this into a dynamic block instead as it uses a shortcode and any changes to that may be problematic? 