### PR TITLE
fix #535: php warning

### DIFF
--- a/src/assets/blocks/recent-posts/block.php
+++ b/src/assets/blocks/recent-posts/block.php
@@ -894,13 +894,15 @@ function advgbGetTaxonomyTerms( $post_type, $post_id, $front_end = false, $use_t
 	foreach( $taxonomies as $slug => $tax ) {
 		$terms = get_the_terms( $post_id, $slug );
 		$linked = $unlinked = array();
-		foreach( $terms as $term ) {
-			if ( $front_end ) {
-				$linked[] = sprintf( '<div><a href="%s" class="advgb-post-tax-term">%s</a></div>', esc_url( get_term_link( $term->slug, $slug ) ), esc_html( $term->name ) );
-				$unlinked[] = sprintf( '<div><span class="advgb-post-tax-term">%s</span></div>', esc_html( $term->name ) );
-			} else {
-				$linked[] = sprintf( '<a href="%s" class="advgb-post-tax-term">%s</a>', esc_url( get_term_link( $term->slug, $slug ) ), esc_html( $term->name ) );
-				$unlinked[] = sprintf( '<span class="advgb-post-tax-term">%s</span>', esc_html( $term->name ) );
+		if ( $terms ) {
+			foreach( $terms as $term ) {
+				if ( $front_end ) {
+					$linked[] = sprintf( '<div><a href="%s" class="advgb-post-tax-term">%s</a></div>', esc_url( get_term_link( $term->slug, $slug ) ), esc_html( $term->name ) );
+					$unlinked[] = sprintf( '<div><span class="advgb-post-tax-term">%s</span></div>', esc_html( $term->name ) );
+				} else {
+					$linked[] = sprintf( '<a href="%s" class="advgb-post-tax-term">%s</a>', esc_url( get_term_link( $term->slug, $slug ) ), esc_html( $term->name ) );
+					$unlinked[] = sprintf( '<span class="advgb-post-tax-term">%s</span>', esc_html( $term->name ) );
+				}
 			}
 		}
 		$info[ $use_tax_slug ? $slug : html_entity_decode( $tax->label, ENT_QUOTES ) ] = array( 'linked' => $linked, 'unlinked' => $unlinked, 'slug' => $slug, 'name' => esc_html( $tax->label ) );

--- a/src/assets/blocks/recent-posts/block.php
+++ b/src/assets/blocks/recent-posts/block.php
@@ -124,6 +124,7 @@ function advgbRenderBlockRecentPosts($attributes)
 						'taxonomy' => $slug,
 						'field' => 'name',
 						'terms' => $terms,
+						'include_children' => false,
 						'operator' => 'IN',
 				);
 			}


### PR DESCRIPTION
- fixes php warning `PHP Warning: Invalid argument supplied for foreach() in wp-content/plugins/advanced-gutenberg/assets/blocks/recent-posts/block.php on line 897`
- fixes a specific case where a custom taxonomy has a hierarchy as below

![image](https://user-images.githubusercontent.com/12953439/119962041-46f6b280-bfc4-11eb-8e1c-5671ca9366d3.png)

If we filter by `twentyone` in the editor, it shows 1 post but in the front end it shows 2 posts because it shows the child too.
