### PR TITLE
Fixed "Notice: Undefined variable: $saved_settings"

### DIFF
--- a/src/incl/advanced-gutenberg-main.php
+++ b/src/incl/advanced-gutenberg-main.php
@@ -4703,9 +4703,7 @@ if(!class_exists('AdvancedGutenbergMain')) {
             }
 
             if (strpos($content, 'wp-block-gallery') !== false) {
-                if (!$saved_settings) {
-                    $saved_settings = get_option('advgb_settings');
-                }
+                $saved_settings = get_option('advgb_settings');
 
                 if ($saved_settings['gallery_lightbox']) {
                     wp_enqueue_style('colorbox_style');


### PR DESCRIPTION
There is a PHP message `Notice: Undefined variable: $saved_settings"`. This is caused by historical changes in source code. Fixed by this commit.