### PR TITLE
fix/#1511-Tab-Block-mobile-tabs-should-scroll-to-view-after-click 

### DIFF
--- a/assets/blocks/advtabs/frontend.js
+++ b/assets/blocks/advtabs/frontend.js
@@ -123,5 +123,7 @@ jQuery(document).ready(function ($) {
         tabsWrapper.find('.advgb-tab-body-header').removeClass('header-active');
         $header.addClass('header-active');
         tabs.eq(idx).find('a, button').first().trigger('click');
+
+        $header[0].scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 });


### PR DESCRIPTION
Tab Block mobile tabs should scroll to view after click fix #1511