### PR TITLE
update/#1698-Rename-PublishPress-Blocks-menu-link-to-Extra-Blocks

### DIFF
--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -1876,7 +1876,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 ],
                 [
                     'slug'     => 'advgb_block_settings',
-                    'title'    => esc_html__('PublishPress Blocks', 'advanced-gutenberg'),
+                    'title'    => esc_html__('Extra Blocks', 'advanced-gutenberg'),
                     'callback' => 'loadBlockSettingsPage',
                     'order'    => 3,
                     'enabled'  => Utilities::settingIsEnabled('enable_advgb_blocks')

--- a/incl/pages/main.php
+++ b/incl/pages/main.php
@@ -28,7 +28,7 @@ defined('ABSPATH') || die;
                         ],
                         [
                             'name' => 'enable_advgb_blocks',
-                            'title' => __('PublishPress Blocks', 'advanced-gutenberg'),
+                            'title' => __('Extra Blocks', 'advanced-gutenberg'),
                             'description' => __(
                                 'Enable extra blocks including content displays, sliders, buttons, icons, tabs, accordions, and more.',
                                 'advanced-gutenberg'


### PR DESCRIPTION
Rename "PublishPress Blocks" menu link to "Extra Blocks" fix #1698