### PR TITLE
fix/#1728-Double-check-text-domain-loading-for-translation-files-from-translate.wordpress.org 

### DIFF
--- a/init.php
+++ b/init.php
@@ -16,16 +16,18 @@ if (! function_exists('advg_language_domain_init')) {
      */
     function advg_language_domain_init()
     {
-        load_plugin_textdomain('advanced-gutenberg', false, dirname(plugin_basename(__FILE__)) . '/languages');
+        $domain = 'advanced-gutenberg';
+
+        load_plugin_textdomain($domain, false, dirname(plugin_basename(__FILE__)) . '/languages');
 
         wp_set_script_translations(
             'editor',
-            'advanced-gutenberg',
+            $domain,
             plugin_dir_path(__FILE__) . 'languages'
         );
     }
 }
-add_action('init', 'advg_language_domain_init');
+add_action('init', 'advg_language_domain_init', 0);
 
 if (! function_exists('advg_check_legacy_widget_block_init')) {
     /**


### PR DESCRIPTION
Double-check text domain loading for translation files from translate wordpress.org fix #1728