### PR TITLE
fix/#1717-Lightbox-feature-in-PublishPress-Image-block-does-not-work

### DIFF
--- a/assets/blocks/advimage/lightbox.js
+++ b/assets/blocks/advimage/lightbox.js
@@ -8,7 +8,10 @@ jQuery(document).ready(function ( $ ) {
         fixed: true,
         className: 'advgb_lightbox',
         href: function () {
-            return $(this).data('image');
+            const $block = $(this);
+            const $img = $block.find('img.advgb-image').first();
+
+            return $block.data('image') || $img.data('image') || $img.attr('src');
         }
     })
 });


### PR DESCRIPTION
Lightbox feature in PublishPress Image-block does not work fix #1717