### PR TITLE
Fix PHP 8.4 undefined array key warning for colId

### DIFF
--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -5470,7 +5470,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
          */
         public function advgb_AdvancedColumnsStyles($blockAttrs, $blockName)
         {
-            $colID       = esc_html($blockAttrs['colId']);
+            $colID       = esc_html($blockAttrs['colId'] ?? '');
             $marginUnit  = 'px';
             $paddingUnit = 'px';
             if ($blockName === 'advgb/column') {


### PR DESCRIPTION
## Summary

- Fixes `PHP Warning: Undefined array key "colId"` in `advgb_AdvancedColumnsStyles()` on PHP 8.4
- Uses null coalescing operator (`?? ''`) to provide a default empty string when `colId` is absent from `$blockAttrs`

## Change

```php
// Before
$colID = esc_html($blockAttrs['colId']);

// After
$colID = esc_html($blockAttrs['colId'] ?? '');
```

## Test plan

- [ ] Confirm no PHP 8.4 warnings in `advanced-gutenberg-main.php` line 5473
- [ ] Verify advanced columns/column blocks render correctly when `colId` is set
- [ ] Verify no regression when `colId` is absent