### PR TITLE
fix/Contact-Form-and-Newsletter-success-labels-are-appended-as-HTMLcreating-DOM-XSS-risk

### DIFF
--- a/assets/blocks/contact-form/frontend.js
+++ b/assets/blocks/contact-form/frontend.js
@@ -45,7 +45,9 @@ jQuery(document).ready(function ($) {
                 $thisForm.find('.advgb-form-sending').remove();
                 var successText = $thisForm.find('.advgb-form-submit').data('success');
                 successText = successText ? successText : 'Message sent with success!';
-                $thisForm.append('<div class="advgb-form-submit-success">'+ successText +'</div>');
+                $thisForm.append(
+                    $('<div/>', { class: 'advgb-form-submit-success' }).text(successText)
+                );
             },
             error: function ( jqxhr, textStatus, error ) {
                 alert(textStatus + " : " + error + ' - ' + jqxhr.responseJSON);

--- a/assets/blocks/newsletter/frontend.js
+++ b/assets/blocks/newsletter/frontend.js
@@ -64,7 +64,9 @@ jQuery(document).ready(function ($) {
                 $thisForm.find('.advgb-form-sending').remove();
                 var successText = $thisForm.find('.advgb-form-submit').data('success');
                 successText = successText ? successText : __('Submitted with success!', 'advanced-gutenberg');
-                $thisForm.append('<div class="advgb-form-submit-success">'+ successText +'</div>');
+                $thisForm.append(
+                    $('<div/>', { class: 'advgb-form-submit-success' }).text(successText)
+                );
             },
             error: function ( jqxhr, textStatus, error ) {
                 alert(textStatus + " : " + error + ' - ' + jqxhr.responseJSON);


### PR DESCRIPTION
 Contact Form and Newsletter success labels are appended as HTML, creating DOM XSS risk