### PR TITLE
Add Post Notes feature (WordPress 6.9 Notes)

### DIFF
--- a/assets/js/post-notes-editor.js
+++ b/assets/js/post-notes-editor.js
@@ -1,0 +1,123 @@
+/* global wp, navigator */
+(function () {
+    if (! wp || ! wp.element || ! wp.data || ! wp.hooks || ! wp.blockEditor || ! wp.compose) {
+        return;
+    }
+
+    // Setting from PHP (wp_localize_script). Default on if absent.
+    var settings         = window.advgbPostNotes || {};
+    var showBlockToolbar = settings.blockToolbar === undefined ? true : !! settings.blockToolbar;
+
+    if (! showBlockToolbar) {
+        return;
+    }
+
+    var el = wp.element.createElement;
+
+    // Speech bubble with a "+" knocked out as an evenodd cutout, so the plus
+    // stays visible whatever color the toolbar fills the icon with.
+    function NoteIcon() {
+        return el(
+            'svg',
+            {
+                xmlns:   'http://www.w3.org/2000/svg',
+                viewBox: '0 0 24 24',
+                width:   '24',
+                height:  '24',
+            },
+            el('path', {
+                fill:     'currentColor',
+                fillRule: 'evenodd',
+                clipRule: 'evenodd',
+                d: 'M5 4h14a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H8l-4 3V5a1 1 0 0 1 1-1z'
+                 + 'M11 7h2v2h2v2h-2v2h-2v-2H9V9h2z',
+            })
+        );
+    }
+
+    /**
+     * Add a note to a block using WordPress core's own Notes feature.
+     *
+     * Core does not expose a public action to create/anchor a note — the logic
+     * lives in the editor's collab-sidebar and is bound to the
+     * `core/editor/new-note` keyboard shortcut (⌥⌘M / Ctrl+Alt+M), which also
+     * opens core's note composer. We select the block and fire that shortcut so
+     * core performs the create + anchor exactly as its own "Add note" menu item
+     * does. (Core only offers "Add note" in the block options menu; this adds a
+     * top-level toolbar button for it.)
+     */
+    function triggerCoreAddNote(clientId) {
+        var blockEditorDispatch = wp.data.dispatch('core/block-editor');
+        var blockEditorSelect   = wp.data.select('core/block-editor');
+
+        if (! clientId && blockEditorSelect) {
+            clientId = blockEditorSelect.getSelectedBlockClientId();
+        }
+        if (clientId && blockEditorDispatch && blockEditorDispatch.selectBlock) {
+            blockEditorDispatch.selectBlock(clientId);
+        }
+
+        // Dispatch from a node inside the editor's React tree so the delegated
+        // keydown listener (React root) receives the shortcut.
+        var node = (clientId && document.querySelector('[data-block="' + clientId + '"]'))
+            || document.activeElement
+            || document.body;
+        if (node && node.focus) {
+            try { node.focus(); } catch (e) {}
+        }
+
+        // primaryAlt = Cmd+Alt on macOS, Ctrl+Alt elsewhere; character "m"
+        var isMac = /Mac|iPhone|iPad/i.test((navigator && navigator.platform) || '');
+        var event = new KeyboardEvent('keydown', {
+            key:        'm',
+            code:       'KeyM',
+            keyCode:    77,
+            which:      77,
+            metaKey:    isMac,
+            ctrlKey:    ! isMac,
+            altKey:     true,
+            bubbles:    true,
+            cancelable: true,
+        });
+
+        // Defer a tick so block selection settles before the shortcut fires
+        setTimeout(function () {
+            (node || document).dispatchEvent(event);
+        }, 0);
+    }
+
+    // Top-level "Add note" button on every block's toolbar
+    var BlockControls = wp.blockEditor.BlockControls;
+    var ToolbarGroup  = wp.components.ToolbarGroup;
+    var ToolbarButton = wp.components.ToolbarButton;
+    var createHOC     = wp.compose.createHigherOrderComponent;
+
+    var withNoteToolbarButton = createHOC(function (BlockEdit) {
+        return function (props) {
+            return el(
+                wp.element.Fragment,
+                null,
+                el(BlockEdit, props),
+                props.isSelected && el(
+                    BlockControls,
+                    { group: 'other' },
+                    el(
+                        ToolbarGroup,
+                        null,
+                        el(ToolbarButton, {
+                            icon:    el(NoteIcon, null),
+                            label:   'Add note',
+                            onClick: function () { triggerCoreAddNote(props.clientId); },
+                        })
+                    )
+                )
+            );
+        };
+    }, 'withNoteToolbarButton');
+
+    wp.hooks.addFilter(
+        'editor.BlockEdit',
+        'advgb/post-notes-toolbar-button',
+        withNoteToolbarButton
+    );
+})();

--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -582,6 +582,36 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 }
             }
 
+            // Post Notes: Add Note button in block editor toolbar (WP 6.9+)
+            if (Utilities::settingIsEnabled('enable_post_notes')) {
+                wp_enqueue_script(
+                    'advgb_post_notes_editor',
+                    ADVANCED_GUTENBERG_PLUGIN_DIR_URL . 'assets/js/post-notes-editor.js',
+                    array(
+                        'wp-plugins',
+                        'wp-element',
+                        'wp-data',
+                        'wp-components',
+                        'wp-editor',
+                        'wp-block-editor',
+                        'wp-hooks',
+                        'wp-compose',
+                    ),
+                    ADVANCED_GUTENBERG_VERSION,
+                    true
+                );
+
+                $advgb_settings = get_option('advgb_settings');
+                wp_localize_script(
+                    'advgb_post_notes_editor',
+                    'advgbPostNotes',
+                    array(
+                        // Default on when the setting has never been saved
+                        'blockToolbar' => ! isset($advgb_settings['post_notes_block_toolbar']) || $advgb_settings['post_notes_block_toolbar'],
+                    )
+                );
+            }
+
             // Include needed JS libraries
             wp_enqueue_script('jquery-ui-tabs');
             wp_enqueue_script('jquery-ui-sortable');
@@ -2210,10 +2240,18 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 'enabled'  => Utilities::settingIsEnabled( 'auto_insert_blocks' )
                 ],
                 [
+                    'slug'       => 'advgb_post_notes',
+                    'title'      => esc_html__('Post Notes', 'advanced-gutenberg'),
+                    'callback'   => 'loadPostNotesPage',
+                    'order'      => 9,
+                    'enabled'    => Utilities::settingIsEnabled('enable_post_notes'),
+                    'capability' => 'edit_posts',
+                ],
+                [
                     'slug'     => 'advgb_settings',
                     'title'    => esc_html__('Settings', 'advanced-gutenberg'),
                     'callback' => 'loadSettingsPage',
-                    'order'    => 9,
+                    'order'    => 10,
                     'enabled'  => true
                 ]
             ];
@@ -2228,7 +2266,10 @@ if (! class_exists('AdvancedGutenbergMain')) {
          */
         public function registerMainMenu()
         {
-            if (! current_user_can('manage_options')) {
+            /* Admins get the full menu. Users who can edit posts still get the menu
+             * registered so the Post Notes submenu (capability: edit_posts) is reachable;
+             * WordPress promotes the top-level menu to the first submenu they can access. */
+            if (! current_user_can('manage_options') && ! current_user_can('edit_posts')) {
                 return false;
             }
 
@@ -2251,7 +2292,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
                         'advgb_main',
                         $page['title'],
                         $page['title'],
-                        'manage_options',
+                        $page['capability'] ?? 'manage_options',
                         $page['slug'],
                         // slug should use underscores, not hyphen due we generate automatic function names based on it
                         ! empty($page['callback']) ? [ $this, $page['callback'] ] : '',
@@ -2521,6 +2562,22 @@ if (! class_exists('AdvancedGutenbergMain')) {
             $this->blocksUsageData();
 
             $this->blocksUsagePage();
+        }
+
+        /**
+         * Post Notes page
+         *
+         * @return void
+         */
+        public function loadPostNotesPage()
+        {
+            if (! current_user_can('edit_posts')) {
+                return false;
+            }
+
+            self::commonAdminPagesAssets();
+
+            require_once plugin_dir_path(dirname(__FILE__)) . 'incl/pages/post-notes.php';
         }
 
         /**
@@ -2999,7 +3056,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 update_option('advgb_settings', $advgb_settings);
 
                 if (isset($_REQUEST['_wp_http_referer'])) {
-                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=general&save=success'));
+                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=extra-blocks&subtab=general&save=success'));
                     exit;
                 }
             } // Images settings
@@ -3025,7 +3082,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 update_option('advgb_settings', $advgb_settings);
 
                 if (isset($_REQUEST['_wp_http_referer'])) {
-                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=images&save=success'));
+                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=extra-blocks&subtab=images&save=success'));
                     exit;
                 }
             } // Images settings
@@ -3068,7 +3125,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 update_option('advgb_settings', $advgb_settings);
 
                 if (isset($_REQUEST['_wp_http_referer'])) {
-                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=maps&save=success'));
+                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=extra-blocks&subtab=maps&save=success'));
                     exit;
                 }
             } // Email & forms settings
@@ -3096,7 +3153,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
 
                 if (isset($_REQUEST['_wp_http_referer'])) {
                     wp_safe_redirect(
-                        admin_url('admin.php?page=advgb_settings&tab=forms&save=success')
+                        admin_url('admin.php?page=advgb_settings&tab=extra-blocks&subtab=forms&save=success')
                     );
                     exit; // @TODO - Do we really need this?
                 }
@@ -3130,7 +3187,7 @@ if (! class_exists('AdvancedGutenbergMain')) {
 
                 if (isset($_REQUEST['_wp_http_referer'])) {
                     wp_safe_redirect(
-                        admin_url('admin.php?page=advgb_settings&tab=recaptcha&save=success')
+                        admin_url('admin.php?page=advgb_settings&tab=extra-blocks&subtab=recaptcha&save=success')
                     );
                     exit;
                 }
@@ -3167,6 +3224,27 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 }
 
                 return false;
+            } // Post Notes settings
+            elseif (isset($_POST['save_settings_post_notes'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- we check nonce below
+                if (
+                    ! wp_verify_nonce(
+                        sanitize_key($_POST['advgb_settings_post_notes_nonce_field']),
+                        'advgb_settings_post_notes_nonce'
+                    )
+                ) {
+                    return false;
+                }
+
+                $advgb_settings = get_option('advgb_settings');
+
+                $advgb_settings['post_notes_block_toolbar'] = isset($_POST['post_notes_block_toolbar']) ? 1 : 0;
+
+                update_option('advgb_settings', $advgb_settings);
+
+                if (isset($_REQUEST['_wp_http_referer'])) {
+                    wp_safe_redirect(admin_url('admin.php?page=advgb_settings&tab=post-notes&save=success'));
+                    exit;
+                }
             }
 
             return false;

--- a/incl/pages/main.php
+++ b/incl/pages/main.php
@@ -86,6 +86,16 @@ defined('ABSPATH') || die;
                             'access' => true
                         ],
                         [
+                            'name' => 'enable_post_notes',
+                            'title' => __('Post Notes', 'advanced-gutenberg'),
+                            'description' => __(
+                                'Adds an "Add Note" button to the block editor toolbar and a Post Notes admin page to review all notes across your posts (requires WordPress 6.9+).',
+                                'advanced-gutenberg'
+                            ),
+                            'default' => 1,
+                            'access' => true
+                        ],
+                        [
                             'name' => 'enable_core_blocks_features',
                             'title' => __('Core Blocks Features', 'advanced-gutenberg'),
                             'description' => __(

--- a/incl/pages/post-notes.php
+++ b/incl/pages/post-notes.php
@@ -1,0 +1,365 @@
+<?php
+defined('ABSPATH') || die;
+
+$current_user      = wp_get_current_user();
+$can_edit_others   = current_user_can('edit_others_posts');
+$per_page          = 20;
+$current_page      = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
+$filter_status     = isset($_GET['note_status']) ? sanitize_text_field($_GET['note_status']) : '';
+$filter_post_type  = isset($_GET['post_type_filter']) ? sanitize_text_field($_GET['post_type_filter']) : '';
+$filter_search     = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+$page_url          = admin_url('admin.php?page=advgb_post_notes');
+
+// Build status arg
+$status_arg = 'all';
+if ($filter_status === 'open') {
+    $status_arg = 'hold';
+} elseif ($filter_status === 'resolved') {
+    $status_arg = 'approve';
+}
+
+// Resolve which post IDs to restrict notes to
+$post_id_limit = null; // null = no restriction (admins/editors who can edit others' posts)
+
+if (! $can_edit_others) {
+    // Authors/contributors: only their own posts
+    $own_posts = get_posts([
+        'author'         => $current_user->ID,
+        'posts_per_page' => -1,
+        'post_type'      => 'any',
+        'post_status'    => 'any',
+        'fields'         => 'ids',
+    ]);
+    $post_id_limit = ! empty($own_posts) ? $own_posts : [0];
+}
+
+// Post type filter: resolve to post IDs and intersect with existing limit
+if ($filter_post_type) {
+    $type_posts = get_posts([
+        'posts_per_page' => -1,
+        'post_type'      => $filter_post_type,
+        'post_status'    => 'any',
+        'fields'         => 'ids',
+    ]);
+    if (empty($type_posts)) {
+        $post_id_limit = [0];
+    } elseif ($post_id_limit === null) {
+        $post_id_limit = $type_posts;
+    } else {
+        $post_id_limit = array_intersect($post_id_limit, $type_posts);
+        if (empty($post_id_limit)) {
+            $post_id_limit = [0];
+        }
+    }
+}
+
+// Post title search: resolve to post IDs and intersect
+if ($filter_search) {
+    $search_posts = get_posts([
+        'posts_per_page' => -1,
+        'post_type'      => 'any',
+        'post_status'    => 'any',
+        's'              => $filter_search,
+        'fields'         => 'ids',
+    ]);
+    if (empty($search_posts)) {
+        $post_id_limit = [0];
+    } elseif ($post_id_limit === null) {
+        $post_id_limit = $search_posts;
+    } else {
+        $post_id_limit = array_intersect($post_id_limit, $search_posts);
+        if (empty($post_id_limit)) {
+            $post_id_limit = [0];
+        }
+    }
+}
+
+// Base comment query args — parent=0 excludes internal resolution child comments WP may create
+$base_args = [
+    'type'    => 'note',
+    'status'  => $status_arg,
+    'parent'  => 0,
+    'orderby' => 'comment_date',
+    'order'   => 'DESC',
+];
+if ($post_id_limit !== null) {
+    $base_args['post__in'] = array_values($post_id_limit);
+}
+
+// Total count
+$count_args          = $base_args;
+$count_args['count'] = true;
+$total_notes         = get_comments($count_args);
+$total_pages         = $total_notes > 0 ? (int) ceil($total_notes / $per_page) : 1;
+$current_page        = min($current_page, $total_pages);
+
+// Paginated results
+$query_args           = $base_args;
+$query_args['number'] = $per_page;
+$query_args['offset'] = ($current_page - 1) * $per_page;
+$notes                = get_comments($query_args);
+
+// Post types for filter dropdown (public, excluding attachments)
+$post_types = get_post_types(['public' => true], 'objects');
+unset($post_types['attachment']);
+
+/**
+ * Render an initials avatar matching the WP 6.9 Notes editor style.
+ * Color is deterministically derived from the author name so each
+ * author always gets the same hue across page loads.
+ */
+function advgb_note_author_avatar($name, $email = '', $size = 32)
+{
+    // Extract up to two initials
+    $parts    = array_filter(explode(' ', trim($name)));
+    $initials = '';
+    foreach (array_slice($parts, 0, 2) as $part) {
+        $initials .= mb_strtoupper(mb_substr($part, 0, 1));
+    }
+    if ($initials === '') {
+        $initials = '?';
+    }
+
+    // Pick from a palette of visually distinct colors, deterministically by name
+    $palette = [
+        '#e74c3c', // red
+        '#e67e22', // orange
+        '#f39c12', // amber
+        '#27ae60', // green
+        '#16a085', // teal
+        '#2980b9', // blue
+        '#8e44ad', // purple
+        '#c0392b', // dark red
+        '#1abc9c', // mint
+        '#2c3e50', // navy
+        '#d35400', // burnt orange
+        '#7f8c8d', // slate
+    ];
+    $bg_color = $palette[ abs(crc32($name)) % count($palette) ];
+    $font_size = (int) ($size * 0.4);
+
+    // Request avatar with default=404 so missing Gravatars don't load the mystery-man image.
+    // The <img> overlays the initials; onerror hides it and lets the initials show through.
+    $img_tag = '';
+    if ($email) {
+        $avatar_url = get_avatar_url($email, ['size' => $size * 2, 'default' => '404']);
+        if ($avatar_url) {
+            $img_tag = sprintf(
+                '<img src="%s" width="%d" height="%d" alt="" '
+                    . 'style="position:absolute;inset:0;width:100%%;height:100%%;'
+                    . 'border-radius:50%%;object-fit:cover;" '
+                    . 'onerror="this.style.display=\'none\'">',
+                esc_url($avatar_url),
+                (int) $size,
+                (int) $size
+            );
+        }
+    }
+
+    printf(
+        '<span class="advgb-note-avatar" aria-hidden="true" style="'
+            . 'position:relative;display:inline-flex;align-items:center;justify-content:center;'
+            . 'width:%1$dpx;height:%1$dpx;border-radius:50%%;overflow:hidden;'
+            . 'background:%2$s;color:#fff;font-size:%3$dpx;'
+            . 'font-weight:600;flex-shrink:0;line-height:1;'
+            . 'font-family:-apple-system,BlinkMacSystemFont,sans-serif;'
+            . '">%4$s%5$s</span>',
+        (int) $size,
+        esc_attr($bg_color),
+        (int) $font_size,
+        esc_html($initials),
+        $img_tag
+    );
+}
+
+// Pagination helper
+$pagination_args = [
+    'base'               => add_query_arg('paged', '%#%', $page_url),
+    'format'             => '',
+    'current'            => $current_page,
+    'total'              => $total_pages,
+    'prev_text'          => '&laquo;',
+    'next_text'          => '&raquo;',
+    'before_page_number' => '',
+];
+if ($filter_status) {
+    $pagination_args['base'] = add_query_arg('note_status', $filter_status, $pagination_args['base']);
+}
+if ($filter_post_type) {
+    $pagination_args['base'] = add_query_arg('post_type_filter', $filter_post_type, $pagination_args['base']);
+}
+if ($filter_search) {
+    $pagination_args['base'] = add_query_arg('s', $filter_search, $pagination_args['base']);
+}
+?>
+
+<div class="publishpress-admin wrap">
+    <header>
+        <h1 class="wp-heading-inline">
+            <?php esc_html_e('Post Notes', 'advanced-gutenberg') ?>
+        </h1>
+    </header>
+
+    <div class="wrap">
+        <form method="get" action="<?php echo esc_url(admin_url('admin.php')) ?>">
+            <input type="hidden" name="page" value="advgb_post_notes">
+
+            <div class="tablenav top">
+                <div class="alignleft actions">
+
+                    <select name="post_type_filter">
+                        <option value=""><?php esc_html_e('All post types', 'advanced-gutenberg') ?></option>
+                        <?php foreach ($post_types as $pt) : ?>
+                            <option value="<?php echo esc_attr($pt->name) ?>"
+                                <?php selected($filter_post_type, $pt->name) ?>>
+                                <?php echo esc_html($pt->label) ?>
+                            </option>
+                        <?php endforeach ?>
+                    </select>
+
+                    <select name="note_status">
+                        <option value=""><?php esc_html_e('All statuses', 'advanced-gutenberg') ?></option>
+                        <option value="open" <?php selected($filter_status, 'open') ?>>
+                            <?php esc_html_e('Open', 'advanced-gutenberg') ?>
+                        </option>
+                        <option value="resolved" <?php selected($filter_status, 'resolved') ?>>
+                            <?php esc_html_e('Resolved', 'advanced-gutenberg') ?>
+                        </option>
+                    </select>
+
+                    <input type="search"
+                           name="s"
+                           value="<?php echo esc_attr($filter_search) ?>"
+                           placeholder="<?php esc_attr_e('Search by post title…', 'advanced-gutenberg') ?>"
+                           style="width:200px">
+
+                    <?php submit_button(__('Filter', 'advanced-gutenberg'), 'action', '', false) ?>
+
+                    <?php if ($filter_post_type || $filter_status || $filter_search) : ?>
+                        <a href="<?php echo esc_url($page_url) ?>" class="button">
+                            <?php esc_html_e('Reset', 'advanced-gutenberg') ?>
+                        </a>
+                    <?php endif ?>
+                </div>
+
+                <?php if ($total_notes > 0) : ?>
+                <div class="tablenav-pages">
+                    <span class="displaying-num">
+                        <?php printf(
+                            /* translators: %d: number of notes */
+                            esc_html(_n('%d note', '%d notes', $total_notes, 'advanced-gutenberg')),
+                            (int) $total_notes
+                        ) ?>
+                    </span>
+                    <?php echo paginate_links($pagination_args) // phpcs:ignore WordPress.Security.EscapeOutput ?>
+                </div>
+                <?php endif ?>
+            </div><!-- .tablenav.top -->
+
+            <table class="wp-list-table widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th scope="col" style="width:22%"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
+                        <th scope="col" style="width:10%"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <th scope="col" style="width:16%"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <th scope="col" style="width:11%"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <th scope="col" style="width:9%"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (empty($notes)) : ?>
+                        <tr>
+                            <td colspan="6">
+                                <?php esc_html_e('No notes found.', 'advanced-gutenberg') ?>
+                            </td>
+                        </tr>
+                    <?php else : ?>
+                        <?php foreach ($notes as $note) :
+                            $post       = get_post($note->comment_post_ID);
+                            $edit_url   = $post ? get_edit_post_link($post->ID) : '';
+                            $post_title = $post ? ($post->post_title ?: __('(no title)', 'advanced-gutenberg')) : __('(deleted)', 'advanced-gutenberg');
+                            $post_type  = $post ? get_post_type_object($post->post_type) : null;
+                            $resolved   = ($note->comment_approved === '1');
+                        ?>
+                        <tr>
+                            <td>
+                                <?php if ($edit_url) : ?>
+                                    <a href="<?php echo esc_url($edit_url) ?>">
+                                        <?php echo esc_html($post_title) ?>
+                                    </a>
+                                <?php else : ?>
+                                    <span><?php echo esc_html($post_title) ?></span>
+                                <?php endif ?>
+                            </td>
+                            <td>
+                                <?php echo $post_type ? esc_html($post_type->labels->singular_name) : '&mdash;' ?>
+                            </td>
+                            <td>
+                                <?php echo esc_html(wp_trim_words($note->comment_content, 20)) ?>
+                            </td>
+                            <td>
+                                <div style="display:flex;align-items:center;gap:8px">
+                                    <?php advgb_note_author_avatar($note->comment_author, $note->comment_author_email, 32) ?>
+                                    <span><?php echo esc_html($note->comment_author) ?></span>
+                                </div>
+                            </td>
+                            <td>
+                                <abbr title="<?php echo esc_attr($note->comment_date) ?>">
+                                    <?php echo esc_html(
+                                        date_i18n(get_option('date_format'), strtotime($note->comment_date))
+                                    ) ?>
+                                </abbr>
+                            </td>
+                            <td>
+                                <span class="advgb-note-status advgb-note-status--<?php echo $resolved ? 'resolved' : 'open' ?>">
+                                    <?php echo $resolved
+                                        ? esc_html__('Resolved', 'advanced-gutenberg')
+                                        : esc_html__('Open', 'advanced-gutenberg') ?>
+                                </span>
+                            </td>
+                        </tr>
+                        <?php endforeach ?>
+                    <?php endif ?>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th scope="col"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <th scope="col"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                    </tr>
+                </tfoot>
+            </table>
+
+            <?php if ($total_pages > 1) : ?>
+            <div class="tablenav bottom">
+                <div class="tablenav-pages">
+                    <?php echo paginate_links($pagination_args) // phpcs:ignore WordPress.Security.EscapeOutput ?>
+                </div>
+            </div>
+            <?php endif ?>
+
+        </form>
+    </div><!-- .wrap -->
+</div><!-- .publishpress-admin.wrap -->
+
+<style>
+.advgb-note-status {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: 600;
+}
+.advgb-note-status--open {
+    background: #fff3cd;
+    color: #856404;
+}
+.advgb-note-status--resolved {
+    background: #d4edda;
+    color: #155724;
+}
+</style>

--- a/incl/pages/settings.php
+++ b/incl/pages/settings.php
@@ -1,12 +1,43 @@
 <?php
 defined('ABSPATH') || die;
 
-$allowed_tabs = ['general', 'block-features', 'images', 'maps', 'forms', 'recaptcha', 'data', 'license'];
-$current_tab = 'general';
-if (isset($_GET['tab']) && !empty($_GET['tab'])) {
-    $requested_tab = sanitize_text_field($_GET['tab']);
-    if (in_array($requested_tab, $allowed_tabs, true)) {
-        $current_tab = $requested_tab;
+/*
+ * Two-level settings tabs.
+ *
+ * Top-level tabs: Extra Blocks, Block Features, Post Notes, License.
+ * The "Extra Blocks" tab groups these sub-tabs:
+ *   General, Images, Maps, Email & Forms, reCAPTCHA, Data Export.
+ *
+ * Legacy deep-links (e.g. ?tab=maps, used by some blocks) are mapped to the
+ * matching Extra Blocks sub-tab so they keep working.
+ */
+
+// Sub-tabs that live under "Extra Blocks"
+$extra_blocks_subtabs = ['general'];
+if ($this->settingIsEnabled('enable_advgb_blocks')) {
+    array_push($extra_blocks_subtabs, 'images', 'maps', 'forms', 'recaptcha', 'data');
+}
+
+// Allowed top-level tabs
+$allowed_top_tabs = ['extra-blocks', 'block-features', 'post-notes', 'license'];
+
+$current_tab    = 'extra-blocks';
+$current_subtab = 'general';
+
+$requested_tab = isset($_GET['tab']) ? sanitize_text_field($_GET['tab']) : '';
+
+if (in_array($requested_tab, $extra_blocks_subtabs, true)) {
+    // Legacy deep-link to a sub-tab slug
+    $current_tab    = 'extra-blocks';
+    $current_subtab = $requested_tab;
+} elseif (in_array($requested_tab, $allowed_top_tabs, true)) {
+    $current_tab = $requested_tab;
+
+    if ($current_tab === 'extra-blocks') {
+        $requested_subtab = isset($_GET['subtab']) ? sanitize_text_field($_GET['subtab']) : '';
+        if (in_array($requested_subtab, $extra_blocks_subtabs, true)) {
+            $current_subtab = $requested_subtab;
+        }
     }
 }
 ?>
@@ -30,8 +61,8 @@ if (isset($_GET['tab']) && !empty($_GET['tab'])) {
     <?php
     $tabs = [
         [
-            'title' => esc_html__('General', 'advanced-gutenberg'),
-            'slug' => 'general'
+            'title' => esc_html__('Extra Blocks', 'advanced-gutenberg'),
+            'slug' => 'extra-blocks'
         ],
         [
             'title' => esc_html__('Block Features', 'advanced-gutenberg'),
@@ -39,28 +70,12 @@ if (isset($_GET['tab']) && !empty($_GET['tab'])) {
         ]
     ];
 
-    if ($this->settingIsEnabled('enable_advgb_blocks')) {
+    if ($this->settingIsEnabled('enable_post_notes')) {
         array_push(
             $tabs,
             [
-                'title' => esc_html__('Images', 'advanced-gutenberg'),
-                'slug' => 'images'
-            ],
-            [
-                'title' => esc_html__('Maps', 'advanced-gutenberg'),
-                'slug' => 'maps'
-            ],
-            [
-                'title' => esc_html__('Email & Forms', 'advanced-gutenberg'),
-                'slug' => 'forms'
-            ],
-            [
-                'title' => esc_html__('reCAPTCHA', 'advanced-gutenberg'),
-                'slug' => 'recaptcha'
-            ],
-            [
-                'title' => esc_html__('Data Export', 'advanced-gutenberg'),
-                'slug' => 'data'
+                'title' => esc_html__('Post Notes', 'advanced-gutenberg'),
+                'slug' => 'post-notes'
             ]
         );
     }
@@ -75,7 +90,7 @@ if (isset($_GET['tab']) && !empty($_GET['tab'])) {
         );
     }
 
-    // Output tabs menu
+    // Output top-level tabs menu
     echo $this->buildTabs(
         'advgb_settings',
         $current_tab,
@@ -85,8 +100,40 @@ if (isset($_GET['tab']) && !empty($_GET['tab'])) {
 
     <div class="wrap">
         <?php
-        // Load active settings tab
-        $this->loadPageTab('settings', $current_tab);
+        if ($current_tab === 'extra-blocks') {
+            // Sub-tab navigation for Extra Blocks
+            $subtabs_titles = [
+                'general'   => esc_html__('General', 'advanced-gutenberg'),
+                'images'    => esc_html__('Images', 'advanced-gutenberg'),
+                'maps'      => esc_html__('Maps', 'advanced-gutenberg'),
+                'forms'     => esc_html__('Email & Forms', 'advanced-gutenberg'),
+                'recaptcha' => esc_html__('reCAPTCHA', 'advanced-gutenberg'),
+                'data'      => esc_html__('Data Export', 'advanced-gutenberg'),
+            ];
+
+            echo '<ul class="nav-tab-wrapper advgb-subtab-wrapper" style="margin-top:15px;">';
+            foreach ($extra_blocks_subtabs as $subtab_slug) {
+                if (! isset($subtabs_titles[$subtab_slug])) {
+                    continue;
+                }
+                $subtab_url = admin_url(
+                    'admin.php?page=advgb_settings&tab=extra-blocks&subtab=' . $subtab_slug
+                );
+                printf(
+                    '<li class="nav-tab%1$s"><a href="%2$s">%3$s</a></li>',
+                    ($subtab_slug === $current_subtab ? ' nav-tab-active' : ''),
+                    esc_url($subtab_url),
+                    esc_html($subtabs_titles[$subtab_slug])
+                );
+            }
+            echo '</ul>';
+
+            // Load active sub-tab content
+            $this->loadPageTab('settings', $current_subtab);
+        } else {
+            // Load active top-level tab content (block-features, post-notes, license)
+            $this->loadPageTab('settings', $current_tab);
+        }
         ?>
     </div>
 </div>

--- a/incl/pages/settings/post-notes.php
+++ b/incl/pages/settings/post-notes.php
@@ -1,0 +1,46 @@
+<?php
+
+defined('ABSPATH') || die;
+
+$post_notes_block_toolbar = $this->getOptionSetting('advgb_settings', 'post_notes_block_toolbar', 'checkbox', 1);
+?>
+<form method="post">
+    <?php
+    wp_nonce_field('advgb_settings_post_notes_nonce', 'advgb_settings_post_notes_nonce_field') ?>
+    <table class="form-table">
+        <tr>
+            <th scope="row">
+                <?php _e('Block toolbar icon', 'advanced-gutenberg') ?>
+            </th>
+            <td>
+                <label>
+                    <input type="checkbox"
+                           name="post_notes_block_toolbar"
+                           id="post_notes_block_toolbar"
+                           value="1"
+                        <?php echo esc_attr($post_notes_block_toolbar) ?>
+                    />
+                    <?php _e(
+                        'Show an "Add note" icon in the block toolbar (next to Bold, Italic and Link). It opens the WordPress Notes feature for the selected block.',
+                        'advanced-gutenberg'
+                    ) ?>
+                </label>
+                <p class="description">
+                    <?php _e(
+                        'WordPress core already provides an "All notes" sidebar icon in the editor header to view and resolve notes.',
+                        'advanced-gutenberg'
+                    ) ?>
+                </p>
+            </td>
+        </tr>
+    </table>
+
+    <div class="advgb-form-buttons-bottom">
+        <button type="submit"
+                class="button button-primary"
+                name="save_settings_post_notes"
+        >
+            <?php esc_html_e('Save Post Notes Settings', 'advanced-gutenberg') ?>
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
## Summary

Adds a **Post Notes** feature built on the [WordPress 6.9 Notes](https://make.wordpress.org/core/2025/11/15/notes-feature-in-wordpress-6-9/) capability.

### What's included

- **Post Notes admin page** (under the Blocks menu) — a table of all notes across posts:
  - Columns: Post (linked to edit), Post Type, Note, Author (colored initials avatar, overlaid with the real avatar when one exists), Date, Status.
  - Filters: post type, status (Open/Resolved), post-title search; pagination (20/page).
  - Access: available to any user with `edit_posts`. `registerMainMenu()` also registers for `edit_posts` users so the submenu is reachable; non-admins see only their own posts' notes.
- **Top-level "Add note" button in the block toolbar.** Core only offers "Add note" in the block options (⋮) menu — this surfaces it at the top level of the toolbar. It **delegates to core**: it selects the block and fires core's own `core/editor/new-note` flow, so the note is created and anchored by WordPress itself (no custom comment creation, no `metadata.noteId` handling). Viewing/resolving uses core's native "All notes" sidebar.
- **Settings**: a new **Post Notes** tab (toggle the toolbar button). The existing General / Images / Maps / Email & Forms / reCAPTCHA / Data Export tabs are now grouped under a new **Extra Blocks** top-level tab. Legacy `?tab=…` deep-links (used by some blocks, e.g. Maps/Forms/reCAPTCHA) are preserved as aliases.
- **Dashboard toggle** (`enable_post_notes`) to enable/disable the whole feature.

### Notes

- Requires WordPress 6.9+ for the Notes capability. On older versions the admin list simply shows no notes (no errors), and the toolbar button is a no-op.
- The editor JS uses plain `wp.*` globals — no build step.

### Files

- `incl/pages/post-notes.php` (new) — admin listing page
- `assets/js/post-notes-editor.js` (new) — block-toolbar button that triggers core's Notes flow
- `incl/pages/settings/post-notes.php` (new) — Post Notes settings tab
- `incl/pages/settings.php` — two-level tabs (Extra Blocks grouping + legacy aliases)
- `incl/pages/main.php` — Dashboard feature toggle
- `incl/advanced-gutenberg-main.php` — submenu + capability, page loader, asset enqueue/localize, settings save handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)