### PR TITLE
Add Screen Options to the Post Notes admin page

### DIFF
--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -43,6 +43,10 @@ if (! class_exists('AdvancedGutenbergMain')) {
             global $wp_version;
 
             add_action('init', array( $this, 'registerPostMeta' ));
+            /* Must be registered unconditionally (not inside a load-{page} hook): core
+             * saves the Screen Options "per page" value during admin_init, which runs
+             * before load-{page} fires. */
+            add_filter('set_screen_option_advgb_post_notes_per_page', array( $this, 'setPostNotesScreenOption' ), 10, 3);
             add_action('init', array( $this, 'registerCustomStyleFrontendFilter' ));
             add_action('admin_init', array( $this, 'registerStylesScripts' ));
             add_action('admin_init', array( $this, 'addEditorFrameStyles' ));
@@ -2580,6 +2584,11 @@ if (! class_exists('AdvancedGutenbergMain')) {
                         // e.g. 'load-blocks_page_advgb_block_access'
                         add_action('load-' . $hook, [ $this, $function_name ]);
                     }
+
+                    // Screen Options (per-page + column visibility) for Post Notes
+                    if (! empty($hook) && $page['slug'] === 'advgb_post_notes') {
+                        add_action('load-' . $hook, [ $this, 'addPostNotesScreenOptions' ]);
+                    }
                 }
 
                 /* Add CSS classes to these submenus to dynamically show/hide them
@@ -2851,6 +2860,59 @@ if (! class_exists('AdvancedGutenbergMain')) {
             self::commonAdminPagesAssets();
 
             require_once plugin_dir_path(dirname(__FILE__)) . 'incl/pages/post-notes.php';
+        }
+
+        /**
+         * Register the "Screen Options" tab content for the Post Notes page:
+         * a "Notes per page" number field and column show/hide checkboxes.
+         * Must run on load-{page}, before admin-header.php renders the tab.
+         *
+         * @return void
+         */
+        public function addPostNotesScreenOptions()
+        {
+            add_screen_option('per_page', [
+                'label'   => __('Notes per page', 'advanced-gutenberg'),
+                'default' => 20,
+                'option'  => 'advgb_post_notes_per_page',
+            ]);
+
+            $screen = get_current_screen();
+            if (! $screen) {
+                return;
+            }
+
+            add_filter('manage_' . $screen->id . '_columns', function () {
+                return [
+                    // '_title' is the core-recognized key for a mandatory, non-hideable column
+                    '_title'    => __('Post', 'advanced-gutenberg'),
+                    'post_type' => __('Post Type', 'advanced-gutenberg'),
+                    'note'      => __('Note', 'advanced-gutenberg'),
+                    'author'    => __('Author', 'advanced-gutenberg'),
+                    'date'      => __('Date', 'advanced-gutenberg'),
+                    'status'    => __('Status', 'advanced-gutenberg'),
+                ];
+            });
+        }
+
+        /**
+         * Validate/save the "Notes per page" Screen Option value.
+         *
+         * @param mixed  $status Screen option value to save, or false to skip.
+         * @param string $option Screen option name being saved.
+         * @param mixed  $value  Value submitted by the user.
+         *
+         * @return mixed
+         */
+        public function setPostNotesScreenOption($status, $option, $value)
+        {
+            if ($option === 'advgb_post_notes_per_page') {
+                $value = (int) $value;
+
+                return ($value > 0) ? $value : $status;
+            }
+
+            return $status;
         }
 
         /**

--- a/incl/pages/post-notes.php
+++ b/incl/pages/post-notes.php
@@ -3,7 +3,20 @@ defined('ABSPATH') || die;
 
 $current_user      = wp_get_current_user();
 $can_edit_others   = current_user_can('edit_others_posts');
-$per_page          = 20;
+
+// "Notes per page" Screen Option (Settings > Screen Options, top right of this page)
+$per_page = (int) get_user_meta($current_user->ID, 'advgb_post_notes_per_page', true);
+if ($per_page < 1) {
+    $per_page = 20;
+}
+
+// Column visibility from Screen Options; '_title' (Post) is always shown
+$advgb_screen  = get_current_screen();
+$hidden_cols   = $advgb_screen ? get_hidden_columns($advgb_screen) : [];
+$advgb_show_col = function ($key) use ($hidden_cols) {
+    return ! in_array($key, $hidden_cols, true);
+};
+
 $current_page      = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
 $filter_status     = isset($_GET['note_status']) ? sanitize_text_field($_GET['note_status']) : '';
 $filter_post_type  = isset($_GET['post_type_filter']) ? sanitize_text_field($_GET['post_type_filter']) : '';
@@ -265,21 +278,40 @@ if ($filter_search) {
                 <?php endif ?>
             </div><!-- .tablenav.top -->
 
+            <?php
+            // Column count for the "no notes" placeholder row (Post is always shown)
+            $advgb_visible_cols = 1;
+            foreach (['post_type', 'note', 'author', 'date', 'status'] as $advgb_col_key) {
+                if ($advgb_show_col($advgb_col_key)) {
+                    $advgb_visible_cols++;
+                }
+            }
+            ?>
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
                         <th scope="col" style="width:22%"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:10%"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:16%"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:11%"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:9%"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php if ($advgb_show_col('post_type')) : ?>
+                            <th scope="col" style="width:10%"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('note')) : ?>
+                            <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('author')) : ?>
+                            <th scope="col" style="width:16%"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('date')) : ?>
+                            <th scope="col" style="width:11%"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('status')) : ?>
+                            <th scope="col" style="width:9%"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
                     </tr>
                 </thead>
                 <tbody>
                     <?php if (empty($notes)) : ?>
                         <tr>
-                            <td colspan="6">
+                            <td colspan="<?php echo (int) $advgb_visible_cols ?>">
                                 <?php esc_html_e('No notes found.', 'advanced-gutenberg') ?>
                             </td>
                         </tr>
@@ -301,32 +333,42 @@ if ($filter_search) {
                                     <span><?php echo esc_html($post_title) ?></span>
                                 <?php endif ?>
                             </td>
-                            <td>
-                                <?php echo $post_type ? esc_html($post_type->labels->singular_name) : '&mdash;' ?>
-                            </td>
-                            <td>
-                                <?php echo esc_html(wp_trim_words($note->comment_content, 20)) ?>
-                            </td>
-                            <td>
-                                <div style="display:flex;align-items:center;gap:8px">
-                                    <?php advgb_note_author_avatar($note->comment_author, $note->comment_author_email, 32) ?>
-                                    <span><?php echo esc_html($note->comment_author) ?></span>
-                                </div>
-                            </td>
-                            <td>
-                                <abbr title="<?php echo esc_attr($note->comment_date) ?>">
-                                    <?php echo esc_html(
-                                        date_i18n(get_option('date_format'), strtotime($note->comment_date))
-                                    ) ?>
-                                </abbr>
-                            </td>
-                            <td>
-                                <span class="advgb-note-status advgb-note-status--<?php echo $resolved ? 'resolved' : 'open' ?>">
-                                    <?php echo $resolved
-                                        ? esc_html__('Resolved', 'advanced-gutenberg')
-                                        : esc_html__('Open', 'advanced-gutenberg') ?>
-                                </span>
-                            </td>
+                            <?php if ($advgb_show_col('post_type')) : ?>
+                                <td>
+                                    <?php echo $post_type ? esc_html($post_type->labels->singular_name) : '&mdash;' ?>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('note')) : ?>
+                                <td>
+                                    <?php echo esc_html(wp_trim_words($note->comment_content, 20)) ?>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('author')) : ?>
+                                <td>
+                                    <div style="display:flex;align-items:center;gap:8px">
+                                        <?php advgb_note_author_avatar($note->comment_author, $note->comment_author_email, 32) ?>
+                                        <span><?php echo esc_html($note->comment_author) ?></span>
+                                    </div>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('date')) : ?>
+                                <td>
+                                    <abbr title="<?php echo esc_attr($note->comment_date) ?>">
+                                        <?php echo esc_html(
+                                            date_i18n(get_option('date_format'), strtotime($note->comment_date))
+                                        ) ?>
+                                    </abbr>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('status')) : ?>
+                                <td>
+                                    <span class="advgb-note-status advgb-note-status--<?php echo $resolved ? 'resolved' : 'open' ?>">
+                                        <?php echo $resolved
+                                            ? esc_html__('Resolved', 'advanced-gutenberg')
+                                            : esc_html__('Open', 'advanced-gutenberg') ?>
+                                    </span>
+                                </td>
+                            <?php endif ?>
                         </tr>
                         <?php endforeach ?>
                     <?php endif ?>
@@ -334,11 +376,21 @@ if ($filter_search) {
                 <tfoot>
                     <tr>
                         <th scope="col"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php if ($advgb_show_col('post_type')) : ?>
+                            <th scope="col"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('note')) : ?>
+                            <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('author')) : ?>
+                            <th scope="col"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('date')) : ?>
+                            <th scope="col"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('status')) : ?>
+                            <th scope="col"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
                     </tr>
                 </tfoot>
             </table>


### PR DESCRIPTION
## Summary

Adds a native WordPress **Screen Options** tab to the Post Notes admin page (Blocks → Post Notes), matching the standard behavior seen on Posts/Pages list screens.

- **Notes per page** — a number field to control how many notes are shown per page (saved per-user, default 20).
- **Column visibility** — checkboxes to show/hide the Post Type, Note, Author, Date, and Status columns. The **Post** column is always shown (it's the primary identifying column).

Pagination itself was already in place on this screen from #1823; this adds the ability to change the page size and pick which columns are visible, via the same Screen Options mechanism WordPress core list tables use.

### Implementation

- `add_screen_option('per_page', …)` plus a `manage_{screen_id}_columns` filter, both registered on the page's `load-{hook}` action — after the current screen is set, before `admin-header.php` renders the Screen Options tab.
- The `set_screen_option_{option}` save filter is registered **unconditionally in the constructor**, since core validates/saves the submitted value during `admin_init`, which runs *before* `load-{hook}` fires (a `load`-hook-only registration would miss the save).
- `post-notes.php` reads the saved per-page value (user meta) and hidden columns (`get_hidden_columns()`), and conditionally renders each `<th>`/`<td>`. The "no notes found" colspan adjusts to the visible column count.

### Files

- `incl/advanced-gutenberg-main.php` — screen options registration, save handler
- `incl/pages/post-notes.php` — per-page + column-visibility read, conditional column rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)