### PR TITLE
Post Notes counters: editor toolbar badge + sortable Posts column

### DIFF
--- a/assets/js/post-notes-editor.js
+++ b/assets/js/post-notes-editor.js
@@ -1,4 +1,4 @@
-/* global wp, navigator */
+/* global wp, navigator, document, MutationObserver */
 (function () {
     if (! wp || ! wp.element || ! wp.data || ! wp.hooks || ! wp.blockEditor || ! wp.compose) {
         return;
@@ -7,10 +7,6 @@
     // Setting from PHP (wp_localize_script). Default on if absent.
     var settings         = window.advgbPostNotes || {};
     var showBlockToolbar = settings.blockToolbar === undefined ? true : !! settings.blockToolbar;
-
-    if (! showBlockToolbar) {
-        return;
-    }
 
     var el = wp.element.createElement;
 
@@ -87,37 +83,107 @@
     }
 
     // Top-level "Add note" button on every block's toolbar
-    var BlockControls = wp.blockEditor.BlockControls;
-    var ToolbarGroup  = wp.components.ToolbarGroup;
-    var ToolbarButton = wp.components.ToolbarButton;
-    var createHOC     = wp.compose.createHigherOrderComponent;
+    if (showBlockToolbar) {
+        var BlockControls = wp.blockEditor.BlockControls;
+        var ToolbarGroup  = wp.components.ToolbarGroup;
+        var ToolbarButton = wp.components.ToolbarButton;
+        var createHOC     = wp.compose.createHigherOrderComponent;
 
-    var withNoteToolbarButton = createHOC(function (BlockEdit) {
-        return function (props) {
-            return el(
-                wp.element.Fragment,
-                null,
-                el(BlockEdit, props),
-                props.isSelected && el(
-                    BlockControls,
-                    { group: 'other' },
-                    el(
-                        ToolbarGroup,
-                        null,
-                        el(ToolbarButton, {
-                            icon:    el(NoteIcon, null),
-                            label:   'Add note',
-                            onClick: function () { triggerCoreAddNote(props.clientId); },
-                        })
+        var withNoteToolbarButton = createHOC(function (BlockEdit) {
+            return function (props) {
+                return el(
+                    wp.element.Fragment,
+                    null,
+                    el(BlockEdit, props),
+                    props.isSelected && el(
+                        BlockControls,
+                        { group: 'other' },
+                        el(
+                            ToolbarGroup,
+                            null,
+                            el(ToolbarButton, {
+                                icon:    el(NoteIcon, null),
+                                label:   'Add note',
+                                onClick: function () { triggerCoreAddNote(props.clientId); },
+                            })
+                        )
                     )
-                )
-            );
-        };
-    }, 'withNoteToolbarButton');
+                );
+            };
+        }, 'withNoteToolbarButton');
 
-    wp.hooks.addFilter(
-        'editor.BlockEdit',
-        'advgb/post-notes-toolbar-button',
-        withNoteToolbarButton
-    );
+        wp.hooks.addFilter(
+            'editor.BlockEdit',
+            'advgb/post-notes-toolbar-button',
+            withNoteToolbarButton
+        );
+    }
+
+    /**
+     * Open-notes counter on core's "All notes" toolbar icon.
+     *
+     * The count is computed server-side and passed in via wp_localize_script
+     * (advgbPostNotes.openNotesCount) — no REST request needed here. This JS
+     * only finds core's button and overlays a badge. Core re-renders its
+     * header on state changes, so a light interval re-applies the badge if
+     * React wipes it.
+     */
+    (function () {
+        var count = parseInt(settings.openNotesCount, 10) || 0;
+        if (! count) {
+            return;
+        }
+
+        var styleInjected = false;
+
+        function findNotesButton() {
+            var candidates = document.querySelectorAll(
+                '.interface-pinned-items button, '
+                + '.editor-header__settings button, '
+                + '.edit-post-header__settings button'
+            );
+            for (var i = 0; i < candidates.length; i++) {
+                var text = (
+                    (candidates[i].getAttribute('aria-label') || '')
+                    + ' ' + (candidates[i].getAttribute('title') || '')
+                ).toLowerCase();
+                if (text.indexOf('note') !== -1) {
+                    return candidates[i];
+                }
+            }
+
+            return null;
+        }
+
+        function applyBadge() {
+            var button = findNotesButton();
+            if (! button || button.querySelector('.advgb-notes-badge')) {
+                return;
+            }
+
+            if (! styleInjected) {
+                styleInjected = true;
+                var style = document.createElement('style');
+                style.textContent =
+                    '.advgb-notes-badge{position:absolute;top:-2px;right:-2px;min-width:15px;'
+                    + 'height:15px;padding:0 3px;border-radius:999px;background:#d63638;'
+                    + 'color:#fff;font-size:10px;font-weight:600;line-height:15px;'
+                    + 'text-align:center;pointer-events:none;z-index:1;}';
+                document.head.appendChild(style);
+            }
+
+            if (! button.style.position) {
+                button.style.position = 'relative';
+            }
+            var badge = document.createElement('span');
+            badge.className   = 'advgb-notes-badge';
+            badge.textContent = count > 99 ? '99+' : String(count);
+            badge.setAttribute('aria-hidden', 'true');
+            button.appendChild(badge);
+        }
+
+        // The header renders asynchronously (and re-renders); keep re-applying.
+        applyBadge();
+        setInterval(applyBadge, 1000);
+    })();
 })();

--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -43,6 +43,10 @@ if (! class_exists('AdvancedGutenbergMain')) {
             global $wp_version;
 
             add_action('init', array( $this, 'registerPostMeta' ));
+            /* Must be registered unconditionally (not inside a load-{page} hook): core
+             * saves the Screen Options "per page" value during admin_init, which runs
+             * before load-{page} fires. */
+            add_filter('set_screen_option_advgb_post_notes_per_page', array( $this, 'setPostNotesScreenOption' ), 10, 3);
             add_action('init', array( $this, 'registerCustomStyleFrontendFilter' ));
             add_action('admin_init', array( $this, 'registerStylesScripts' ));
             add_action('admin_init', array( $this, 'addEditorFrameStyles' ));
@@ -2580,6 +2584,11 @@ if (! class_exists('AdvancedGutenbergMain')) {
                         // e.g. 'load-blocks_page_advgb_block_access'
                         add_action('load-' . $hook, [ $this, $function_name ]);
                     }
+
+                    // Screen Options (per-page + column visibility) for Post Notes
+                    if (! empty($hook) && $page['slug'] === 'advgb_post_notes') {
+                        add_action('load-' . $hook, [ $this, 'addPostNotesScreenOptions' ]);
+                    }
                 }
 
                 /* Add CSS classes to these submenus to dynamically show/hide them
@@ -2851,6 +2860,59 @@ if (! class_exists('AdvancedGutenbergMain')) {
             self::commonAdminPagesAssets();
 
             require_once plugin_dir_path(dirname(__FILE__)) . 'incl/pages/post-notes.php';
+        }
+
+        /**
+         * Register the "Screen Options" tab content for the Post Notes page:
+         * a "Notes per page" number field and column show/hide checkboxes.
+         * Must run on load-{page}, before admin-header.php renders the tab.
+         *
+         * @return void
+         */
+        public function addPostNotesScreenOptions()
+        {
+            add_screen_option('per_page', [
+                'label'   => __('Notes per page', 'advanced-gutenberg'),
+                'default' => 20,
+                'option'  => 'advgb_post_notes_per_page',
+            ]);
+
+            $screen = get_current_screen();
+            if (! $screen) {
+                return;
+            }
+
+            add_filter('manage_' . $screen->id . '_columns', function () {
+                return [
+                    // '_title' is the core-recognized key for a mandatory, non-hideable column
+                    '_title'    => __('Post', 'advanced-gutenberg'),
+                    'post_type' => __('Post Type', 'advanced-gutenberg'),
+                    'note'      => __('Note', 'advanced-gutenberg'),
+                    'author'    => __('Author', 'advanced-gutenberg'),
+                    'date'      => __('Date', 'advanced-gutenberg'),
+                    'status'    => __('Status', 'advanced-gutenberg'),
+                ];
+            });
+        }
+
+        /**
+         * Validate/save the "Notes per page" Screen Option value.
+         *
+         * @param mixed  $status Screen option value to save, or false to skip.
+         * @param string $option Screen option name being saved.
+         * @param mixed  $value  Value submitted by the user.
+         *
+         * @return mixed
+         */
+        public function setPostNotesScreenOption($status, $option, $value)
+        {
+            if ($option === 'advgb_post_notes_per_page') {
+                $value = (int) $value;
+
+                return ($value > 0) ? $value : $status;
+            }
+
+            return $status;
         }
 
         /**

--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -47,6 +47,18 @@ if (! class_exists('AdvancedGutenbergMain')) {
              * saves the Screen Options "per page" value during admin_init, which runs
              * before load-{page} fires. */
             add_filter('set_screen_option_advgb_post_notes_per_page', array( $this, 'setPostNotesScreenOption' ), 10, 3);
+
+            // "Notes" column (open notes count) on the Posts/Pages list screens
+            if (is_admin() && Utilities::settingIsEnabled('enable_post_notes')) {
+                add_filter('manage_posts_columns', array( $this, 'addPostNotesColumn' ));
+                add_filter('manage_pages_columns', array( $this, 'addPostNotesColumn' ));
+                add_action('manage_posts_custom_column', array( $this, 'renderPostNotesColumn' ), 10, 2);
+                add_action('manage_pages_custom_column', array( $this, 'renderPostNotesColumn' ), 10, 2);
+                add_action('admin_head-edit.php', array( $this, 'printPostNotesColumnStyles' ));
+                add_filter('manage_edit-post_sortable_columns', array( $this, 'addPostNotesSortableColumn' ));
+                add_filter('manage_edit-page_sortable_columns', array( $this, 'addPostNotesSortableColumn' ));
+                add_filter('posts_clauses', array( $this, 'sortPostsByNotesClauses' ), 10, 2);
+            }
             add_action('init', array( $this, 'registerCustomStyleFrontendFilter' ));
             add_action('admin_init', array( $this, 'registerStylesScripts' ));
             add_action('admin_init', array( $this, 'addEditorFrameStyles' ));
@@ -635,12 +647,28 @@ if (! class_exists('AdvancedGutenbergMain')) {
                 );
 
                 $advgb_settings = get_option('advgb_settings');
+
+                // Count open notes server-side (same query as the Posts screen
+                // column), so the editor badge JS needs no REST request.
+                $advgb_open_notes = 0;
+                $advgb_editor_post = get_post();
+                if ($advgb_editor_post) {
+                    $advgb_open_notes = (int) get_comments([
+                        'post_id' => $advgb_editor_post->ID,
+                        'type'    => 'note',
+                        'status'  => 'hold',
+                        'parent'  => 0,
+                        'count'   => true,
+                    ]);
+                }
+
                 wp_localize_script(
                     'advgb_post_notes_editor',
                     'advgbPostNotes',
                     array(
                         // Default on when the setting has never been saved
-                        'blockToolbar' => ! isset($advgb_settings['post_notes_block_toolbar']) || $advgb_settings['post_notes_block_toolbar'],
+                        'blockToolbar'   => ! isset($advgb_settings['post_notes_block_toolbar']) || $advgb_settings['post_notes_block_toolbar'],
+                        'openNotesCount' => $advgb_open_notes,
                     )
                 );
             }
@@ -2860,6 +2888,220 @@ if (! class_exists('AdvancedGutenbergMain')) {
             self::commonAdminPagesAssets();
 
             require_once plugin_dir_path(dirname(__FILE__)) . 'incl/pages/post-notes.php';
+        }
+
+        /**
+         * Add a "Notes" column to the Posts/Pages list screens, placed after
+         * the built-in comments column when present.
+         *
+         * @param array $columns Existing list table columns.
+         *
+         * @return array
+         */
+        public function addPostNotesColumn($columns)
+        {
+            $new = [];
+            foreach ($columns as $key => $label) {
+                $new[$key] = $label;
+                if ($key === 'comments') {
+                    $new['advgb_notes'] = __('Notes', 'advanced-gutenberg');
+                }
+            }
+            // No comments column on this screen: append before Date, or at the end
+            if (! isset($new['advgb_notes'])) {
+                if (isset($new['date'])) {
+                    $date = $new['date'];
+                    unset($new['date']);
+                    $new['advgb_notes'] = __('Notes', 'advanced-gutenberg');
+                    $new['date']        = $date;
+                } else {
+                    $new['advgb_notes'] = __('Notes', 'advanced-gutenberg');
+                }
+            }
+
+            return $new;
+        }
+
+        /**
+         * Mark the "Notes" column sortable on the Posts/Pages list screens.
+         *
+         * @param array $columns Sortable columns (column key => orderby value).
+         *
+         * @return array
+         */
+        public function addPostNotesSortableColumn($columns)
+        {
+            // 'desc' as third arg would set initial direction; keep WP default (asc)
+            $columns['advgb_notes'] = 'advgb_notes';
+
+            return $columns;
+        }
+
+        /**
+         * Order the Posts/Pages list by open-notes count when the Notes column
+         * header is clicked. The count is computed live (not stored as meta),
+         * so sorting needs a LEFT JOIN on the comments table.
+         *
+         * @param array     $clauses SQL clauses for the query.
+         * @param \WP_Query $query   Current query.
+         *
+         * @return array
+         */
+        public function sortPostsByNotesClauses($clauses, $query)
+        {
+            if (! is_admin() || ! $query->is_main_query()) {
+                return $clauses;
+            }
+
+            if ($query->get('orderby') !== 'advgb_notes') {
+                return $clauses;
+            }
+
+            global $wpdb;
+
+            // Open notes: type "note", status hold (comment_approved '0'), top-level
+            $clauses['join'] .= " LEFT JOIN {$wpdb->comments} advgb_note_count"
+                . " ON advgb_note_count.comment_post_ID = {$wpdb->posts}.ID"
+                . " AND advgb_note_count.comment_type = 'note'"
+                . " AND advgb_note_count.comment_approved = '0'"
+                . " AND advgb_note_count.comment_parent = 0";
+
+            $clauses['groupby'] = "{$wpdb->posts}.ID";
+
+            $order              = strtoupper($query->get('order')) === 'DESC' ? 'DESC' : 'ASC';
+            $clauses['orderby'] = "COUNT(advgb_note_count.comment_ID) {$order}, {$wpdb->posts}.post_date DESC";
+
+            return $clauses;
+        }
+
+        /**
+         * Print bubble styles for the Notes column. Core's comment-bubble CSS is
+         * scoped to .column-comments in list-tables.css, so the same classes render
+         * unstyled in our column — these rules mirror core's, scoped to ours.
+         *
+         * @return void
+         */
+        public function printPostNotesColumnStyles()
+        {
+            ?>
+            <style>
+            /* Copied verbatim from core list-tables.css (.column-comments rules) */
+            .column-advgb_notes .post-com-count-wrapper {
+                white-space: nowrap;
+                word-wrap: normal;
+            }
+            .column-advgb_notes .post-com-count {
+                display: inline-block;
+                vertical-align: top;
+                text-decoration: none;
+            }
+            .column-advgb_notes .post-com-count-approved {
+                margin-top: 5px;
+            }
+            .column-advgb_notes .comment-count-approved {
+                box-sizing: border-box;
+                display: block;
+                padding: 0 8px;
+                min-width: 24px;
+                height: 2em;
+                border-radius: 5px;
+                background-color: #646970;
+                color: #fff;
+                font-size: 11px;
+                font-weight: 400;
+                line-height: 1.90909090;
+                text-align: center;
+            }
+            .column-advgb_notes .post-com-count-approved:after {
+                content: "";
+                display: block;
+                margin-left: 8px;
+                width: 0;
+                height: 0;
+                border-top: 5px solid #646970;
+                border-right: 5px solid transparent;
+            }
+            .column-advgb_notes a.post-com-count-approved:hover .comment-count-approved,
+            .column-advgb_notes a.post-com-count-approved:focus .comment-count-approved {
+                background: #2271b1;
+            }
+            .column-advgb_notes a.post-com-count-approved:hover:after,
+            .column-advgb_notes a.post-com-count-approved:focus:after {
+                border-top-color: #2271b1;
+            }
+            </style>
+            <?php
+        }
+
+        /**
+         * Render the "Notes" column: a badge with the count of open (unresolved)
+         * notes on the post, linking to the post editor. Shows a dash when the
+         * post has no open notes.
+         *
+         * @param string $column  Column key being rendered.
+         * @param int    $post_id Current post ID.
+         *
+         * @return void
+         */
+        public function renderPostNotesColumn($column, $post_id)
+        {
+            if ($column !== 'advgb_notes') {
+                return;
+            }
+
+            $open_notes = get_comments([
+                'post_id' => $post_id,
+                'type'    => 'note',
+                'status'  => 'hold',
+                'parent'  => 0,
+                'count'   => true,
+            ]);
+
+            if (! $open_notes) {
+                echo '<span aria-hidden="true">&mdash;</span>';
+                echo '<span class="screen-reader-text">' . esc_html__('No open notes', 'advanced-gutenberg') . '</span>';
+
+                return;
+            }
+
+            $edit_link = get_edit_post_link($post_id);
+            $sr_text   = sprintf(
+                /* translators: %d: number of open notes */
+                esc_html(_n('%d open note', '%d open notes', $open_notes, 'advanced-gutenberg')),
+                (int) $open_notes
+            );
+
+            /* Replicate the default Comments column exactly: core puts the
+             * post-com-count classes on the anchor itself and the count inside
+             * the grey bubble span — reusing that structure verbatim means the
+             * bubble, tail, and hover states all come from core's stylesheet. */
+            $count_label = (int) $open_notes > 99 ? '99+' : (string) (int) $open_notes;
+
+            if ($edit_link) {
+                printf(
+                    '<div class="post-com-count-wrapper">'
+                        . '<a href="%s" title="%s" class="post-com-count post-com-count-approved">'
+                        . '<span class="comment-count-approved" aria-hidden="true">%s</span>'
+                        . '<span class="screen-reader-text">%s</span>'
+                        . '</a>'
+                        . '</div>',
+                    esc_url($edit_link),
+                    esc_attr($sr_text),
+                    esc_html($count_label),
+                    $sr_text // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped above
+                );
+            } else {
+                printf(
+                    '<div class="post-com-count-wrapper">'
+                        . '<span class="post-com-count post-com-count-approved">'
+                        . '<span class="comment-count-approved" aria-hidden="true">%s</span>'
+                        . '<span class="screen-reader-text">%s</span>'
+                        . '</span>'
+                        . '</div>',
+                    esc_html($count_label),
+                    $sr_text // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                );
+            }
         }
 
         /**

--- a/incl/pages/post-notes.php
+++ b/incl/pages/post-notes.php
@@ -3,7 +3,20 @@ defined('ABSPATH') || die;
 
 $current_user      = wp_get_current_user();
 $can_edit_others   = current_user_can('edit_others_posts');
-$per_page          = 20;
+
+// "Notes per page" Screen Option (Settings > Screen Options, top right of this page)
+$per_page = (int) get_user_meta($current_user->ID, 'advgb_post_notes_per_page', true);
+if ($per_page < 1) {
+    $per_page = 20;
+}
+
+// Column visibility from Screen Options; '_title' (Post) is always shown
+$advgb_screen  = get_current_screen();
+$hidden_cols   = $advgb_screen ? get_hidden_columns($advgb_screen) : [];
+$advgb_show_col = function ($key) use ($hidden_cols) {
+    return ! in_array($key, $hidden_cols, true);
+};
+
 $current_page      = max(1, isset($_GET['paged']) ? absint($_GET['paged']) : 1);
 $filter_status     = isset($_GET['note_status']) ? sanitize_text_field($_GET['note_status']) : '';
 $filter_post_type  = isset($_GET['post_type_filter']) ? sanitize_text_field($_GET['post_type_filter']) : '';
@@ -265,21 +278,40 @@ if ($filter_search) {
                 <?php endif ?>
             </div><!-- .tablenav.top -->
 
+            <?php
+            // Column count for the "no notes" placeholder row (Post is always shown)
+            $advgb_visible_cols = 1;
+            foreach (['post_type', 'note', 'author', 'date', 'status'] as $advgb_col_key) {
+                if ($advgb_show_col($advgb_col_key)) {
+                    $advgb_visible_cols++;
+                }
+            }
+            ?>
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
                         <th scope="col" style="width:22%"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:10%"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:16%"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:11%"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
-                        <th scope="col" style="width:9%"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php if ($advgb_show_col('post_type')) : ?>
+                            <th scope="col" style="width:10%"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('note')) : ?>
+                            <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('author')) : ?>
+                            <th scope="col" style="width:16%"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('date')) : ?>
+                            <th scope="col" style="width:11%"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('status')) : ?>
+                            <th scope="col" style="width:9%"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
                     </tr>
                 </thead>
                 <tbody>
                     <?php if (empty($notes)) : ?>
                         <tr>
-                            <td colspan="6">
+                            <td colspan="<?php echo (int) $advgb_visible_cols ?>">
                                 <?php esc_html_e('No notes found.', 'advanced-gutenberg') ?>
                             </td>
                         </tr>
@@ -301,32 +333,42 @@ if ($filter_search) {
                                     <span><?php echo esc_html($post_title) ?></span>
                                 <?php endif ?>
                             </td>
-                            <td>
-                                <?php echo $post_type ? esc_html($post_type->labels->singular_name) : '&mdash;' ?>
-                            </td>
-                            <td>
-                                <?php echo esc_html(wp_trim_words($note->comment_content, 20)) ?>
-                            </td>
-                            <td>
-                                <div style="display:flex;align-items:center;gap:8px">
-                                    <?php advgb_note_author_avatar($note->comment_author, $note->comment_author_email, 32) ?>
-                                    <span><?php echo esc_html($note->comment_author) ?></span>
-                                </div>
-                            </td>
-                            <td>
-                                <abbr title="<?php echo esc_attr($note->comment_date) ?>">
-                                    <?php echo esc_html(
-                                        date_i18n(get_option('date_format'), strtotime($note->comment_date))
-                                    ) ?>
-                                </abbr>
-                            </td>
-                            <td>
-                                <span class="advgb-note-status advgb-note-status--<?php echo $resolved ? 'resolved' : 'open' ?>">
-                                    <?php echo $resolved
-                                        ? esc_html__('Resolved', 'advanced-gutenberg')
-                                        : esc_html__('Open', 'advanced-gutenberg') ?>
-                                </span>
-                            </td>
+                            <?php if ($advgb_show_col('post_type')) : ?>
+                                <td>
+                                    <?php echo $post_type ? esc_html($post_type->labels->singular_name) : '&mdash;' ?>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('note')) : ?>
+                                <td>
+                                    <?php echo esc_html(wp_trim_words($note->comment_content, 20)) ?>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('author')) : ?>
+                                <td>
+                                    <div style="display:flex;align-items:center;gap:8px">
+                                        <?php advgb_note_author_avatar($note->comment_author, $note->comment_author_email, 32) ?>
+                                        <span><?php echo esc_html($note->comment_author) ?></span>
+                                    </div>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('date')) : ?>
+                                <td>
+                                    <abbr title="<?php echo esc_attr($note->comment_date) ?>">
+                                        <?php echo esc_html(
+                                            date_i18n(get_option('date_format'), strtotime($note->comment_date))
+                                        ) ?>
+                                    </abbr>
+                                </td>
+                            <?php endif ?>
+                            <?php if ($advgb_show_col('status')) : ?>
+                                <td>
+                                    <span class="advgb-note-status advgb-note-status--<?php echo $resolved ? 'resolved' : 'open' ?>">
+                                        <?php echo $resolved
+                                            ? esc_html__('Resolved', 'advanced-gutenberg')
+                                            : esc_html__('Open', 'advanced-gutenberg') ?>
+                                    </span>
+                                </td>
+                            <?php endif ?>
                         </tr>
                         <?php endforeach ?>
                     <?php endif ?>
@@ -334,11 +376,21 @@ if ($filter_search) {
                 <tfoot>
                     <tr>
                         <th scope="col"><?php esc_html_e('Post', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
-                        <th scope="col"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php if ($advgb_show_col('post_type')) : ?>
+                            <th scope="col"><?php esc_html_e('Post Type', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('note')) : ?>
+                            <th scope="col"><?php esc_html_e('Note', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('author')) : ?>
+                            <th scope="col"><?php esc_html_e('Author', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('date')) : ?>
+                            <th scope="col"><?php esc_html_e('Date', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
+                        <?php if ($advgb_show_col('status')) : ?>
+                            <th scope="col"><?php esc_html_e('Status', 'advanced-gutenberg') ?></th>
+                        <?php endif ?>
                     </tr>
                 </tfoot>
             </table>


### PR DESCRIPTION
## Summary

Adds open-notes counters in two places, both counting **open (unresolved)** notes — the same definition used by the Post Notes admin page:

> **Note:** stacked on #1841 (Post Notes Screen Options) — the diff includes those commits until #1841 merges, after which this collapses to just the changes below.

### 1. Editor toolbar badge

A red count badge overlaid on WordPress core's own **"All notes"** icon in the post editor header, showing how many open notes the current post has (Google-Docs-style). 

- The count is computed **server-side at enqueue time** (same `get_comments()` query as the Posts column) and passed in via `wp_localize_script` — the JS is just a small DOM overlay with a re-apply interval for React header re-renders. No REST request, which avoids the comment-status permission edge cases that make client-side counting unreliable for non-admin roles.
- Badge hides when the count is zero; shows "99+" past 99.

### 2. "Notes" column on the Posts/Pages list screens

- Shows the open-notes count in a bubble **visually identical to the default Comments column** — the markup uses core's `post-com-count` structure, and the CSS is copied verbatim from core's `.column-comments` rules in `list-tables.css` (scoped to our column, since core scopes its rules to `.column-comments`).
- Links to the post editor; posts with no open notes show a dash. Placed after the Comments column. Hideable via the screen's native Screen Options.
- **Sortable**: clicking the header orders by open-notes count. Since the count is live (not stored meta), sorting uses a `posts_clauses` `LEFT JOIN` + `COUNT()` with newest-first date as tiebreaker — admin main query only, zero effect elsewhere.

### Files

- `incl/advanced-gutenberg-main.php` — column registration/rendering/styles, sortable handling, server-side count for the editor badge
- `assets/js/post-notes-editor.js` — badge overlay on core's All notes button

🤖 Generated with [Claude Code](https://claude.com/claude-code)