### PR TITLE
Fix PHP 8.3 TypeError in human_time_diff() calls

### DIFF
--- a/assets/blocks/recent-posts/block.php
+++ b/assets/blocks/recent-posts/block.php
@@ -287,10 +287,10 @@ function advgbRenderBlockRecentPosts($attributes)
                                 } else {
                                     if ( $postDate === 'created' ) {
                                         $relativePrefix = $showPrefix ? (isset($attributes['relativeDateCreatedPrefix']) ? $attributes['relativeDateCreatedPrefix'] : esc_html__('Posted', 'advanced-gutenberg')) : '';
-                                        $dateDisplay = ($relativePrefix ? $relativePrefix . ' ' : '') . human_time_diff( get_the_date( 'U', $post->ID ) ) . ' ' . esc_html__( 'ago', 'advanced-gutenberg');
+                                        $dateDisplay = ($relativePrefix ? $relativePrefix . ' ' : '') . human_time_diff( (int) get_the_date( 'U', $post->ID ) ) . ' ' . esc_html__( 'ago', 'advanced-gutenberg');
                                     } else {
                                         $relativePrefix = $showPrefix ? (isset($attributes['relativeDateUpdatedPrefix']) ? $attributes['relativeDateUpdatedPrefix'] : esc_html__('Updated', 'advanced-gutenberg')) : '';
-                                        $dateDisplay = ($relativePrefix ? $relativePrefix . ' ' : '') . human_time_diff( get_the_modified_date( 'U', $post->ID ) ) . ' ' . esc_html__( 'ago', 'advanced-gutenberg');
+                                        $dateDisplay = ($relativePrefix ? $relativePrefix . ' ' : '') . human_time_diff( (int) get_the_modified_date( 'U', $post->ID ) ) . ' ' . esc_html__( 'ago', 'advanced-gutenberg');
                                     }
                                 }
 
@@ -1126,8 +1126,8 @@ function advgbAllowCPTQueryVars($query_params)
 function advgbGetRelativeDates($post)
 {
     return array(
-        'created' => __('Posted', 'advanced-gutenberg') . ' ' . human_time_diff(get_the_date('U', $post['id'])) . ' ' . __('ago', 'advanced-gutenberg'),
-        'modified' => __('Updated', 'advanced-gutenberg') . ' ' . human_time_diff(get_the_modified_date('U', $post['id'])) . ' ' . __('ago', 'advanced-gutenberg')
+        'created' => __('Posted', 'advanced-gutenberg') . ' ' . human_time_diff((int) get_the_date('U', $post['id'])) . ' ' . __('ago', 'advanced-gutenberg'),
+        'modified' => __('Updated', 'advanced-gutenberg') . ' ' . human_time_diff((int) get_the_modified_date('U', $post['id'])) . ' ' . __('ago', 'advanced-gutenberg')
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1858

Casts `get_the_date('U', ...)` and `get_the_modified_date('U', ...)` return values to `(int)` before passing them to `human_time_diff()` in the Recent Posts block.

## Problem

On PHP 8.3 with WordPress 7.x, the Recent Posts block causes a fatal `TypeError` because `get_the_date('U')` returns a **string** timestamp, and `human_time_diff()` in `wp-includes/formatting.php:3947` performs `$to - $from` arithmetic which no longer accepts implicit string-to-int conversion.

```
PHP Fatal error: Uncaught TypeError: Unsupported operand types: int - string
in wp-includes/formatting.php:3947
```

This crashes `wp-admin/post-new.php` and any REST API call that includes the `relative_dates` field.

## Changes

- `assets/blocks/recent-posts/block.php` — added `(int)` cast on 4 lines (290, 293, 1129, 1130)

## Testing

- Verified on PHP 8.3 + WordPress 7.1
- REST API endpoint `/wp-json/wp/v2/posts?_fields=id,relative_dates` returns correct data
- Post editor loads without fatal errors