### PR TITLE
Add labels to admin filter controls

### DIFF
--- a/incl/pages/block-controls/blocks.php
+++ b/incl/pages/block-controls/blocks.php
@@ -7,7 +7,11 @@ defined('ABSPATH') || die;
         <?php
         wp_nonce_field('advgb_controls_block_nonce', 'advgb_controls_block_nonce_field'); ?>
         <div class="advgb-search-wrapper">
+            <label for="advgb-block-search" class="screen-reader-text">
+                <?php esc_html_e('Search blocks', 'advanced-gutenberg') ?>
+            </label>
             <input type="text"
+                   id="advgb-block-search"
                    class="blocks-search-input advgb-search-input"
                    placeholder="<?php
                     esc_attr_e('Search blocks', 'advanced-gutenberg') ?>"

--- a/incl/pages/block-settings.php
+++ b/incl/pages/block-settings.php
@@ -175,7 +175,11 @@ if (defined('ADVANCED_GUTENBERG_PRO_LOADED')) {
     ?>
     <div class="wrap">
         <div class="advgb-search-wrapper" style="padding-bottom: 20px;">
+            <label for="advgb-block-settings-search" class="screen-reader-text">
+                <?php esc_html_e('Search blocks', 'advanced-gutenberg') ?>
+            </label>
             <input type="text"
+                   id="advgb-block-settings-search"
                    class="advgb-search-input blocks-config-search"
                    placeholder="<?php esc_attr_e('Search blocks', 'advanced-gutenberg') ?>"
             >

--- a/incl/pages/post-notes.php
+++ b/incl/pages/post-notes.php
@@ -216,7 +216,10 @@ if ($filter_search) {
             <div class="tablenav top">
                 <div class="alignleft actions">
 
-                    <select name="post_type_filter">
+                    <label for="advgb-post-notes-post-type" class="screen-reader-text">
+                        <?php esc_html_e('Filter by post type', 'advanced-gutenberg') ?>
+                    </label>
+                    <select id="advgb-post-notes-post-type" name="post_type_filter">
                         <option value=""><?php esc_html_e('All post types', 'advanced-gutenberg') ?></option>
                         <?php foreach ($post_types as $pt) : ?>
                             <option value="<?php echo esc_attr($pt->name) ?>"
@@ -226,7 +229,10 @@ if ($filter_search) {
                         <?php endforeach ?>
                     </select>
 
-                    <select name="note_status">
+                    <label for="advgb-post-notes-status" class="screen-reader-text">
+                        <?php esc_html_e('Filter by note status', 'advanced-gutenberg') ?>
+                    </label>
+                    <select id="advgb-post-notes-status" name="note_status">
                         <option value=""><?php esc_html_e('All statuses', 'advanced-gutenberg') ?></option>
                         <option value="open" <?php selected($filter_status, 'open') ?>>
                             <?php esc_html_e('Open', 'advanced-gutenberg') ?>
@@ -236,7 +242,10 @@ if ($filter_search) {
                         </option>
                     </select>
 
-                    <input type="search"
+                    <label for="advgb-post-notes-search" class="screen-reader-text">
+                        <?php esc_html_e('Search by post title', 'advanced-gutenberg') ?>
+                    </label>
+                    <input id="advgb-post-notes-search" type="search"
                            name="s"
                            value="<?php echo esc_attr($filter_search) ?>"
                            placeholder="<?php esc_attr_e('Search by post title…', 'advanced-gutenberg') ?>"


### PR DESCRIPTION
## Summary
- add screen-reader labels to block search fields
- label the Post Notes post type, status, and title filters
- keep existing placeholders and filtering behavior unchanged

## Validation
- php -l incl/pages/block-controls/blocks.php
- php -l incl/pages/block-settings.php
- php -l incl/pages/post-notes.php
- git diff --check