### PR TITLE
[codex] Fix Recent Posts post type placeholder

### DIFF
--- a/assets/blocks/recent-posts/block.php
+++ b/assets/blocks/recent-posts/block.php
@@ -1636,7 +1636,7 @@ function advgbGetPostIdsForTitles($titles, $post_type)
         $placeholders = implode(',', array_fill(0, count($titles), '%s'));
         $params = $titles;
         $params[] = $post_type;
-        $query = $wpdb->prepare("SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ($placeholders) AND post_type = '%s'", $params);
+        $query = $wpdb->prepare("SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ($placeholders) AND post_type = %s", $params);
         return $wpdb->get_col($query);
     }
     return array();


### PR DESCRIPTION
## What changed

Removed the quotes around the `%s` placeholder used for the Recent Posts backward-compatibility title lookup.

## Why

WordPress prepares simple `%s` placeholders with quoting automatically. Keeping the placeholder inside quotes causes Plugin Check / WPCS to report:

> Simple placeholders should not be quoted in the query string in `$wpdb->prepare()`.

## Validation

- `/opt/homebrew/bin/php -l assets/blocks/recent-posts/block.php`

## Stack

This is PR 1 of 3 for the three scanner findings on the same query.
