### PR TITLE
[codex] Inline Recent Posts title placeholders

### DIFF
--- a/assets/blocks/recent-posts/block.php
+++ b/assets/blocks/recent-posts/block.php
@@ -1633,11 +1633,15 @@ function advgbGetPostIdsForTitles($titles, $post_type)
     global $wpdb;
     if (! empty($titles)) {
     // don't use post_name__in here because the title may be different from the slug
-        $placeholders = implode(',', array_fill(0, count($titles), '%s'));
         $params = $titles;
         $params[] = $post_type;
         return $wpdb->get_col(
-            $wpdb->prepare("SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ($placeholders) AND post_type = %s", $params)
+            $wpdb->prepare(
+                "SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ("
+                    . implode(',', array_fill(0, count($titles), '%s'))
+                    . ') AND post_type = %s',
+                $params
+            )
         );
     }
     return array();


### PR DESCRIPTION
## What changed

Removed the interpolated `$placeholders` variable from the Recent Posts title lookup query.

The dynamic `IN` placeholder list is still generated from the number of requested titles, but the generated placeholder string is composed inline inside the prepared query.

## Why

Plugin Check / WPCS reported:

> Use placeholders and `$wpdb->prepare();` found interpolated variable `$placeholders`

The query values continue to be passed through `$wpdb->prepare()`, including every title and the post type.

## Validation

- `/opt/homebrew/bin/php -l assets/blocks/recent-posts/block.php`
- `/opt/homebrew/bin/php vendor/bin/phpcs --standard=.phpcs.xml --sniffs=WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders assets/blocks/recent-posts/block.php`

## Stack

This is PR 3 of 3. It is based on `codex/recent-posts-inline-prepared-query` and should be merged after PRs 1 and 2.
