### PR TITLE
[codex] Use blog option for contact form admin email

### DIFF
--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -1626,7 +1626,9 @@ if (! class_exists('AdvancedGutenbergMain')) {
 				$website_title  = is_multisite()
 					? get_blog_option( get_current_blog_id(), 'blogname' )
 					: get_bloginfo( 'name', 'raw' );
-				$admin_email    = get_option( 'admin_email' );
+				$admin_email    = is_multisite()
+					? get_blog_option( get_current_blog_id(), 'admin_email' )
+					: get_bloginfo( 'admin_email', 'raw' );
 				$sender_name    = isset( $saved_settings['contact_form_sender_name'] ) && $saved_settings['contact_form_sender_name'] ? $saved_settings['contact_form_sender_name'] : $website_title;
 				$sender_email   = isset( $saved_settings['contact_form_sender_email'] ) && $saved_settings['contact_form_sender_email'] ? $saved_settings['contact_form_sender_email'] : $admin_email;
 				$email_title    = isset( $saved_settings['contact_form_email_title'] ) && $saved_settings['contact_form_email_title'] ? $saved_settings['contact_form_email_title'] : __( 'Website Contact',


### PR DESCRIPTION
## What changed

Replaced the contact-form submit path's direct `get_option( 'admin_email' )` lookup with a current-blog-aware lookup.

On multisite, the code now reads the current blog's `admin_email` with `get_blog_option()`. On single-site installs, it uses `get_bloginfo( 'admin_email', 'raw' )` so the code does not depend on multisite-only functions being loaded.

## Why

The scanner flagged `get_option( 'admin_email' )` as a site-level setting lookup that should be current-blog-aware on multisite.

## Validation

- `/opt/homebrew/bin/php -l incl/advanced-gutenberg-main.php`

## Stack

This is PR 2 of 4. It is based on `codex/contact-submit-blogname-get-blog-option` and should be merged after PR 1.
