### PR TITLE
[codex] Use blog option for settings form site title

### DIFF
--- a/incl/pages/settings/forms.php
+++ b/incl/pages/settings/forms.php
@@ -2,7 +2,9 @@
 
 defined('ABSPATH') || die;
 
-$website_title = get_option('blogname');
+$website_title = is_multisite()
+    ? get_blog_option(get_current_blog_id(), 'blogname')
+    : get_bloginfo('name', 'raw');
 $admin_email   = get_option('admin_email');
 
 $contact_form_sender_name    = $this->getOptionSetting(


### PR DESCRIPTION
## What changed

Replaced the contact form settings page's direct `get_option( 'blogname' )` default with a current-blog-aware lookup.

On multisite, the code now reads the current blog's `blogname` with `get_blog_option()`. On single-site installs, it uses `get_bloginfo( 'name', 'raw' )` so the code does not depend on multisite-only functions being loaded.

## Why

The scanner flagged `get_option( 'blogname' )` as a site-level setting lookup that should be current-blog-aware on multisite.

## Validation

- `/opt/homebrew/bin/php -l incl/pages/settings/forms.php`

## Stack

This is PR 3 of 4. It is based on `codex/contact-submit-admin-email-get-blog-option` and should be merged after PRs 1 and 2.
