### PR TITLE
[codex] Use blog option for settings form admin email

### DIFF
--- a/incl/pages/settings/forms.php
+++ b/incl/pages/settings/forms.php
@@ -5,7 +5,9 @@ defined('ABSPATH') || die;
 $website_title = is_multisite()
     ? get_blog_option(get_current_blog_id(), 'blogname')
     : get_bloginfo('name', 'raw');
-$admin_email   = get_option('admin_email');
+$admin_email   = is_multisite()
+    ? get_blog_option(get_current_blog_id(), 'admin_email')
+    : get_bloginfo('admin_email', 'raw');
 
 $contact_form_sender_name    = $this->getOptionSetting(
     'advgb_email_sender',


### PR DESCRIPTION
## What changed

Replaced the contact form settings page's direct `get_option( 'admin_email' )` default with a current-blog-aware lookup.

On multisite, the code now reads the current blog's `admin_email` with `get_blog_option()`. On single-site installs, it uses `get_bloginfo( 'admin_email', 'raw' )` so the code does not depend on multisite-only functions being loaded.

## Why

The scanner flagged `get_option( 'admin_email' )` as a site-level setting lookup that should be current-blog-aware on multisite.

## Validation

- `/opt/homebrew/bin/php -l incl/pages/settings/forms.php`
- `/opt/homebrew/bin/php -l incl/advanced-gutenberg-main.php`
- Confirmed no remaining direct `get_option( 'blogname' )` or `get_option( 'admin_email' )` calls in the flagged files.

## Stack

This is PR 4 of 4. It is based on `codex/settings-form-blogname-get-blog-option` and should be merged after PRs 1, 2, and 3.
