### PR TITLE
[codex] Inline Recent Posts prepared query

### DIFF
--- a/assets/blocks/recent-posts/block.php
+++ b/assets/blocks/recent-posts/block.php
@@ -1636,8 +1636,9 @@ function advgbGetPostIdsForTitles($titles, $post_type)
         $placeholders = implode(',', array_fill(0, count($titles), '%s'));
         $params = $titles;
         $params[] = $post_type;
-        $query = $wpdb->prepare("SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ($placeholders) AND post_type = %s", $params);
-        return $wpdb->get_col($query);
+        return $wpdb->get_col(
+            $wpdb->prepare("SELECT DISTINCT ID FROM {$wpdb->posts} WHERE post_title IN ($placeholders) AND post_type = %s", $params)
+        );
     }
     return array();
 }


### PR DESCRIPTION
## What changed

Inlined the `$wpdb->prepare()` call directly inside `$wpdb->get_col()` for the Recent Posts title lookup.

## Why

The query was already prepared before execution, but storing it in `$query` triggered the scanner warning about passing a query variable to `$wpdb->get_col()`.

## Validation

- `/opt/homebrew/bin/php -l assets/blocks/recent-posts/block.php`

## Stack

This is PR 2 of 3 for the Recent Posts prepared SQL warnings. It is based on `codex/restart-recent-posts-unquote-placeholder`.
