### PR TITLE
[codex] Escape Recent Posts thumbnail captions

### DIFF
--- a/assets/blocks/recent-posts/block.php
+++ b/assets/blocks/recent-posts/block.php
@@ -178,7 +178,10 @@ function advgbRenderBlockRecentPosts($attributes)
             if ($postThumbID) {
                 $postThumb = wp_get_attachment_image($postThumbID, 'large');
                 if (get_the_post_thumbnail_caption($post->ID) && $attributes['displayFeaturedImageCaption']) {
-                    $postThumbCaption = sprintf('<span class="advgb-post-caption">%1$s</span>', get_the_post_thumbnail_caption($post->ID));
+                    $postThumbCaption = sprintf(
+                        '<span class="advgb-post-caption">%1$s</span>',
+                        wp_kses_post(get_the_post_thumbnail_caption($post->ID))
+                    );
                 } else {
                     $postThumbCaption = '';
                 }


### PR DESCRIPTION
## What changed

Escaped the Recent Posts featured image caption before it is inserted into returned block render HTML.

The caption now passes through `wp_kses_post()` at the point the caption span is built, stripping unsafe markup while preserving safe post-content formatting.

## Why

The block render callback returns HTML to WordPress, which WordPress prints verbatim. The attachment caption was inserted into that returned HTML without an escaping or KSES boundary.

## Validation

- `/opt/homebrew/bin/php -l assets/blocks/recent-posts/block.php`
- `/opt/homebrew/bin/php vendor/bin/phpcs --standard=.phpcs.xml --sniffs=WordPress.Security.EscapeOutput assets/blocks/recent-posts/block.php`
