### PR TITLE
[codex] Use blog option for contact form site title

### DIFF
--- a/incl/advanced-gutenberg-main.php
+++ b/incl/advanced-gutenberg-main.php
@@ -1623,7 +1623,9 @@ if (! class_exists('AdvancedGutenbergMain')) {
 			$saved = update_option( 'advgb_contacts_saved', $contacts_saved, false );
 			if ( $saved ) {
 				$saved_settings = get_option( 'advgb_email_sender' );
-				$website_title  = get_option( 'blogname' );
+				$website_title  = is_multisite()
+					? get_blog_option( get_current_blog_id(), 'blogname' )
+					: get_bloginfo( 'name', 'raw' );
 				$admin_email    = get_option( 'admin_email' );
 				$sender_name    = isset( $saved_settings['contact_form_sender_name'] ) && $saved_settings['contact_form_sender_name'] ? $saved_settings['contact_form_sender_name'] : $website_title;
 				$sender_email   = isset( $saved_settings['contact_form_sender_email'] ) && $saved_settings['contact_form_sender_email'] ? $saved_settings['contact_form_sender_email'] : $admin_email;


### PR DESCRIPTION
## What changed

Replaced the contact-form submit path's direct `get_option( 'blogname' )` lookup with a current-blog-aware lookup.

On multisite, it reads the current blog's `blogname` with `get_blog_option()`. On single-site installs, it uses `get_bloginfo( 'name', 'raw' )`.

## Why

The scanner flagged the direct `get_option( 'blogname' )` call as a site-level setting lookup that should be current-blog-aware on multisite.

## Validation

- `/opt/homebrew/bin/php -l incl/advanced-gutenberg-main.php`

## Stack

This is PR 1 of 4 for the multisite option lookup warnings.
