### PR TITLE
[codex] Use blog option for settings form site title

### DIFF
--- a/incl/pages/settings/forms.php
+++ b/incl/pages/settings/forms.php
@@ -2,7 +2,9 @@
 
 defined('ABSPATH') || die;
 
-$website_title = get_option('blogname');
+$website_title = is_multisite()
+    ? get_blog_option(get_current_blog_id(), 'blogname')
+    : get_bloginfo('name', 'raw');
 $admin_email   = get_option('admin_email');
 
 $contact_form_sender_name    = $this->getOptionSetting(


### PR DESCRIPTION
## What changed

Replaced the contact form settings page's direct `get_option( 'blogname' )` default with a current-blog-aware lookup.

On multisite, it reads the current blog's `blogname` with `get_blog_option()`. On single-site installs, it uses `get_bloginfo( 'name', 'raw' )`.

## Why

The scanner flagged the direct `get_option( 'blogname' )` call as a site-level setting lookup that should be current-blog-aware on multisite.

## Validation

- `/opt/homebrew/bin/php -l incl/pages/settings/forms.php`

## Stack

This is PR 3 of 4 for the multisite option lookup warnings. It is based on `codex/restart-contact-submit-admin-email-option`.
